### PR TITLE
Removed .open() and .close() from general_utils.py, replaced by "with" context manager

### DIFF
--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -1,6 +1,7 @@
+import os
 import json
 import tqdm
-from multiprocessing import cpu_count, Pool
+from concurrent.futures import ProcessPoolExecutor
 from typing import Callable, Dict, List
 
 
@@ -43,8 +44,18 @@ def save_json(results: Dict, filename: str) -> None:
 
 
 def parallelise(function: Callable, data: List) -> List:
-    pool = Pool(processes=cpu_count())
-    results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
-    pool.close()
-    pool.join()
+    """
+    Get a function to execute and a list, the function is
+    executed in parallel (the number of workers is depends on the number
+    of the CPU on the local machine).
+
+    Args:
+        function: A function to be called in parallel.
+        data: A list for the function to oparate.
+
+    Returns:
+        A list, the content is dependent on the passed varible called 'data'.
+    """
+    with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
+        results = list(tqdm.tqdm(executor.map(function, data), total=len(data)))
     return results

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -43,7 +43,7 @@ def save_json(results: Dict, filename: str) -> None:
     print('End: Saving duplicates as json!')
 
 
-def parallelise(function: Callable, data: List) -> List:
+def parallelise(function: Callable, data: List, verbose: ) -> List:
     """
     Get a function to execute and a list, the function is
     executed in parallel (the number of workers is depends on the number


### PR DESCRIPTION
Instead of having ```.open()``` and ```.close()```, now there is a context manager called ```with```
for more clean and pythonic code.

Added docstring to the ```parallelise``` function. (**Need review**)

for the issue number #38 