### PR TITLE
Fix duplicates saving with scores for cnn with numpy floats typecaste…

### DIFF
--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -308,7 +308,7 @@ class CNN:
             min_similarity_threshold: Optional, threshold value (must be float between -1.0 and 1.0). Default is 0.9
             scores: Optional, boolean indicating whether similarity scores are to be returned along with retrieved
                     duplicates.
-            outfile: Optional, name of the file to save the results. Default is None.
+            outfile: Optional, name of the file to save the results, must be a json. Default is None.
 
         Returns:
             dictionary: if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -370,7 +370,7 @@ class CNN:
             encoding_map: Optional, used instead of image_dir, a dictionary containing mapping of filenames and
                           corresponding CNN encodings.
             min_similarity_threshold: Optional, threshold value (must be float between -1.0 and 1.0). Default is 0.9
-            outfile: Optional, name of the file to save the results. Default is None.
+            outfile: Optional, name of the file to save the results, must be a json. Default is None.
 
         Returns:
             duplicates: List of image file names that should be removed.

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -246,9 +246,10 @@ class CNN:
 
             self.results[image_ids[i]] = duplicates
 
-        if outfile:
-            save_json(self.results, outfile)
-
+        if outfile and scores:
+            save_json(results=self.results, filename=outfile, float_scores=True)
+        elif outfile:
+            save_json(results=self.results, filename=outfile)
         return self.results
 
     def _find_duplicates_dir(

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -284,7 +284,7 @@ class Hashing:
             max_distance_threshold: Optional, hamming distance between two images below which retrieved duplicates are
                                     valid. (must be an int between 0 and 64). Default is 10.
             scores: Optional, boolean indicating whether Hamming distances are to be returned along with retrieved duplicates.
-            outfile: Optional, name of the file to save the results. Default is None.
+            outfile: Optional, name of the file to save the results, must be a json. Default is None.
 
         Returns:
             duplicates dictionary: if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -344,7 +344,7 @@ class Hashing:
                           corresponding hashes.
             max_distance_threshold: Optional, hamming distance between two images below which retrieved duplicates are
                                     valid. (must be an int between 0 and 64). Default is 10.
-            outfile: Optional, name of the file to save the results.
+            outfile: Optional, name of the file to save the results, must be a json. Default is None.
 
         Returns:
             duplicates: List of image file names that are found to be duplicate of me other file in the directory.

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -38,7 +38,7 @@ def save_json(results: Dict, filename: str, float_scores: bool = False) -> None:
     Args:
         results: Dictionary of results to be saved.
         filename: Name of the file to be saved.
-        float_scores: boolean to indicate of scores are floats.
+        float_scores: boolean to indicate if scores are floats.
     """
     logger.info('Start: Saving duplicates as json!')
 
@@ -53,8 +53,6 @@ def save_json(results: Dict, filename: str, float_scores: bool = False) -> None:
                     typecasted_dup_list.append((dup[0], float(dup[1])))
 
                 results[_file] = typecasted_dup_list
-            else:
-                results[_file] = dup_list
 
         with open(filename, 'w') as f:
             json.dump(results, f, indent=2, sort_keys=True)

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -31,17 +31,34 @@ def get_files_to_remove(duplicates: Dict[str, List]) -> List:
     return list(files_to_remove)
 
 
-def save_json(results: Dict, filename: str) -> None:
+def save_json(results: Dict, filename: str, float_scores: bool = False) -> None:
     """
     Save results with a filename.
 
     Args:
         results: Dictionary of results to be saved.
         filename: Name of the file to be saved.
+        float_scores: boolean to indicate of scores are floats.
     """
     logger.info('Start: Saving duplicates as json!')
-    with open(filename, 'w') as f:
-        json.dump(results, f, indent=2, sort_keys=True)
+
+    if not float_scores:
+        with open(filename, 'w') as f:
+            json.dump(results, f, indent=2, sort_keys=True)
+    else:
+        for _file, dup_list in results.items():
+            if dup_list:
+                typecasted_dup_list = []
+                for dup in dup_list:
+                    typecasted_dup_list.append((dup[0], float(dup[1])))
+
+                results[_file] = typecasted_dup_list
+            else:
+                results[_file] = dup_list
+
+        with open(filename, 'w') as f:
+            json.dump(results, f, indent=2, sort_keys=True)
+
     logger.info('End: Saving duplicates as json!')
 
 

--- a/mkdocs/docs/user_guide/finding_duplicates.md
+++ b/mkdocs/docs/user_guide/finding_duplicates.md
@@ -62,7 +62,7 @@ Each key in the *duplicates* dictionary corresponds to a file in the image direc
 of the find_duplicates function. The value is a list of tuples representing the file names and corresponding scores 
 in the image directory that were found to be duplicates of the key file.
 
-- *outfile*: Name of file to which the returned duplicates dictionary is to be written. *None* by default.
+- *outfile*: Name of file to which the returned duplicates dictionary is to be written, must be a json. *None* by default.
 
 - threshold parameter:
     - *min_similarity_threshold* for cnn method indicating the minimum amount of cosine similarity that should exist 
@@ -153,7 +153,7 @@ corresponding encodings (hashes/cnn encodings). The mentioned dictionary can be 
 the image_dir parameter of the find_duplicates function. The value is a list of all tuples representing the file names 
 and corresponding scores in the image directory that were found to be duplicates for the key file.
 
-- *outfile*: Name of file to which the returned duplicates dictionary is to be written. *None* by default.
+- *outfile*: Name of file to which the returned duplicates dictionary is to be written, must be a json. *None* by default.
 
 - threshold parameter:
     - *min_similarity_threshold* for cnn method indicating the minimum amount of cosine similarity that should exist 

--- a/tests/test_general_utils.py
+++ b/tests/test_general_utils.py
@@ -1,6 +1,9 @@
-from imagededup.utils import general_utils
+import os
+import json
 
-"""Run from project root with: python -m pytest -vs tests/test_general_utils.py"""
+import numpy as np
+
+from imagededup.utils import general_utils
 
 
 def test_get_files_to_remove():
@@ -9,3 +12,47 @@ def test_get_files_to_remove():
     dict_a = OrderedDict({'1': ['2'], '2': ['1', '3'], '3': ['4'], '4': ['3'], '5': []})
     dups_to_remove = general_utils.get_files_to_remove(dict_a)
     assert set(dups_to_remove) == set(['2', '4'])
+
+
+def test_correct_saving_floats():
+    res = {
+        'image1.jpg': [
+            ('image1_duplicate1.jpg', np.float16(0.324)),
+            ('image1_duplicate2.jpg', np.float16(0.324)),
+        ],
+        'image2.jpg': [],
+        'image3.jpg': [('image1_duplicate1.jpg', np.float32(0.324))],
+    }
+    save_file = 'myduplicates.json'
+    general_utils.save_json(results=res, filename=save_file, float_scores=True)
+    with open(save_file, 'r') as f:
+        saved_json = json.load(f)
+
+    assert len(saved_json) == 3  # all valid files present as keys
+    assert isinstance(
+        saved_json['image1.jpg'][0][1], float
+    )  # saved score is of type 'float' for np.float16 score
+    assert isinstance(
+        saved_json['image3.jpg'][0][1], float
+    )  # saved score is of type 'float' for np.float32 score
+
+    os.remove(save_file)  # clean up
+
+
+def test_correct_saving_ints():
+    res = {
+        'image1.jpg': [('image1_duplicate1.jpg', 2), ('image1_duplicate2.jpg', 22)],
+        'image2.jpg': [],
+        'image3.jpg': [('image1_duplicate1.jpg', 43)],
+    }
+    save_file = 'myduplicates.json'
+    general_utils.save_json(results=res, filename=save_file)
+    with open(save_file, 'r') as f:
+        saved_json = json.load(f)
+
+    assert len(saved_json) == 3  # all valid files present as keys
+    assert isinstance(
+        saved_json['image1.jpg'][0][1], int
+    )  # saved score is of type 'int'
+
+    os.remove(save_file)  # clean up


### PR DESCRIPTION
Fix to issue #55.

Converts numpy floats to pure python floats to save to json as json can't save numpy floats.