### PR TITLE
Fix tests

### DIFF
--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -44,7 +44,8 @@ class CNN:
 
         self.target_size = (224, 224)
         self.batch_size = 64
-        self.logger = return_logger(__name__)
+        self.logger = return_logger(__name__)  # The logger needs to be bound to the class, otherwise stderr also gets
+        # directed to stdout (Don't know why that is the case)
         self._build_model()
         self.verbose = 1 if verbose is True else 0
 

--- a/imagededup/utils/logger.py
+++ b/imagededup/utils/logger.py
@@ -11,7 +11,7 @@ def return_logger(name: str) -> logging.Logger:
         # set logging level
         logger.setLevel(logging.DEBUG)
 
-        # Direct logs to stdout
+        # Direct logs to stderr
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(log_formatter)
         logger.addHandler(console_handler)

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -415,8 +415,6 @@ def test_find_duplicates_to_remove_encoding_map(cnn, mocker, mocker_save_json):
 
 # test find_duplicates with directory path
 def test_find_duplicates_dir_integration(cnn):
-    import pkg_resources
-    print('TF version', pkg_resources.get_distribution("tensorflow").version)
     expected_duplicates = {
         'ukbench00120.jpg': [
             ('ukbench00120_hflip.jpg', 0.9672552),

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -237,7 +237,9 @@ def test__find_duplicates_dict_outfile_true(cnn, mocker_save_json):
         scores=scores,
         outfile=outfile,
     )
-    mocker_save_json.assert_called_once_with(results=cnn.results, filename=outfile, float_scores=True)
+    mocker_save_json.assert_called_once_with(
+        results=cnn.results, filename=outfile, float_scores=True
+    )
 
 
 # _find_duplicates_dir
@@ -280,9 +282,7 @@ def test_find_duplicates_dir(cnn, mocker):
     threshold = 0.9
     scores = True
     outfile = True
-    find_dup_dir_mocker = mocker.patch(
-        'imagededup.methods.cnn.CNN._find_duplicates_dir'
-    )
+    find_dup_dir_mocker = mocker.patch('imagededup.methods.cnn.CNN._find_duplicates_dir')
     cnn.find_duplicates(
         image_dir=TEST_IMAGE_DIR,
         min_similarity_threshold=threshold,
@@ -361,10 +361,7 @@ def test_find_duplicates_to_remove_outfile_false(cnn, mocker, mocker_save_json):
 def test_find_duplicates_to_remove_outfile_true(cnn, mocker, mocker_save_json):
     threshold = 0.9
     outfile = True
-    ret_val_find_dup_dict = {
-        'filename.jpg': ['dup1.jpg'],
-        'filename2.jpg': ['dup2.jpg'],
-    }
+    ret_val_find_dup_dict = {'filename.jpg': ['dup1.jpg'], 'filename2.jpg': ['dup2.jpg']}
     ret_val_get_files_to_remove = ['1.jpg', '2.jpg']
 
     find_duplicates_mocker = mocker.patch(
@@ -390,10 +387,7 @@ def test_find_duplicates_to_remove_outfile_true(cnn, mocker, mocker_save_json):
 def test_find_duplicates_to_remove_encoding_map(cnn, mocker, mocker_save_json):
     threshold = 0.9
     outfile = True
-    ret_val_find_dup_dict = {
-        'filename.jpg': ['dup1.jpg'],
-        'filename2.jpg': ['dup2.jpg'],
-    }
+    ret_val_find_dup_dict = {'filename.jpg': ['dup1.jpg'], 'filename2.jpg': ['dup2.jpg']}
     ret_val_get_files_to_remove = ['1.jpg', '2.jpg']
     encoding_map = data_encoding_map()
     find_duplicates_mocker = mocker.patch(
@@ -566,6 +560,7 @@ def test_find_duplicates_verbose_false(capsys):
 
 def test_scores_saving(cnn):
     save_file = 'myduplicates.json'
+    cnn = CNN(verbose=False)
     cnn.find_duplicates(
         image_dir=TEST_IMAGE_DIR_MIXED,
         min_similarity_threshold=0.6,
@@ -576,11 +571,18 @@ def test_scores_saving(cnn):
         saved_json = json.load(f)
 
     assert len(saved_json) == 5  # all valid files present as keys
-    assert len(saved_json['ukbench00120.jpg']) == 3  # file with duplicates have all entries
-    assert len(saved_json['ukbench09268.jpg']) == 0  # file with no duplicates have no entries
+    assert (
+        len(saved_json['ukbench00120.jpg']) == 3
+    )  # file with duplicates have all entries
+    assert (
+        len(saved_json['ukbench09268.jpg']) == 0
+    )  # file with no duplicates have no entries
     assert isinstance(saved_json['ukbench00120.jpg'], list)  # a list of files is returned
-    assert isinstance(saved_json['ukbench00120.jpg'][0], list) # each entry in the duplicate list is a list (not a tuple, since json can't save tuples)
-    assert isinstance(saved_json['ukbench00120.jpg'][0][1], float) # saved score is of type 'float'
+    assert isinstance(
+        saved_json['ukbench00120.jpg'][0], list
+    )  # each entry in the duplicate list is a list (not a tuple, since json can't save tuples)
+    assert isinstance(
+        saved_json['ukbench00120.jpg'][0][1], float
+    )  # saved score is of type 'float'
 
     os.remove(save_file)  # clean up
-

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -415,6 +415,8 @@ def test_find_duplicates_to_remove_encoding_map(cnn, mocker, mocker_save_json):
 
 # test find_duplicates with directory path
 def test_find_duplicates_dir_integration(cnn):
+    import pkg_resources
+    print('TF version', pkg_resources.get_distribution("tensorflow").version)
     expected_duplicates = {
         'ukbench00120.jpg': [
             ('ukbench00120_hflip.jpg', 0.9672552),
@@ -525,7 +527,6 @@ def test_encode_images_verbose_false(capsys):
     cnn = CNN(verbose=False)
     cnn.encode_images(image_dir=TEST_IMAGE_DIR)
     out, err = capsys.readouterr()
-
     assert '' == out
     assert '' == err
 
@@ -560,7 +561,6 @@ def test_find_duplicates_verbose_false(capsys):
 
 def test_scores_saving(cnn):
     save_file = 'myduplicates.json'
-    cnn = CNN(verbose=False)
     cnn.find_duplicates(
         image_dir=TEST_IMAGE_DIR_MIXED,
         min_similarity_threshold=0.6,

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -61,15 +61,13 @@ def test__data_generator():
     assert result.shape == tuple([TEST_BATCH_SIZE, *TEST_TARGET_SIZE, 3])
 
 
-def test_on_epoch_end_1():
-    generator.on_epoch_end()
-
+def test_valid_image_files_1():
     assert generator.valid_image_files == sorted(
         [x for x in IMAGE_DIR.glob('*') if x.is_file()]
     )
 
 
-def test_on_epoch_end_2():
+def test_valid_image_files_2():
     expected = [
         FORMATS_IMAGE_DIR / 'baboon.pgm',
         FORMATS_IMAGE_DIR / 'copyleft.tiff',
@@ -94,5 +92,5 @@ def test_on_epoch_end_2():
     generator.__getitem__(1)
     generator.__getitem__(2)
 
-    generator.on_epoch_end()
+    # generator._update_valid_files()
     assert sorted(generator.valid_image_files, key=lambda x: str(x).lower()) == expected

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -582,7 +582,6 @@ def test_find_duplicates_correctness_score():
     assert isinstance(duplicate_dict, dict)
     duplicates = list(duplicate_dict.values())
     assert isinstance(duplicates[0], list)
-    assert isinstance(duplicates[0][0], tuple)
     assert duplicate_dict['ukbench09268.jpg'] == []
     assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 0)]
 
@@ -607,7 +606,6 @@ def test_find_duplicates_clearing():
     assert isinstance(duplicate_dict, dict)
     duplicates = list(duplicate_dict.values())
     assert isinstance(duplicates[0], list)
-    assert isinstance(duplicates[0][0], tuple)
     assert duplicate_dict['ukbench09268.jpg'] == []
     assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 0)]
 


### PR DESCRIPTION
Currently we have failing Linux tests because we rely on the order of how images are loaded which varies across OSs. We don't care in which order images are loaded so we shouldn't test for it, that's why I removed the lines from `tests/test_hashing.py`

We also have a failing test for macOS Python 3.6 on Azure pipelines which was not reproducible on my MacBook but was fixed by initialising a new CNN object for the failing test. 

