### PR TITLE
Update PyWavelets dependency to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy<1.17
 Pillow<7.0.0
-PyWavelets~=1.0.3
+PyWavelets~=1.1.1
 tqdm
 scikit-learn
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     install_requires=[
         'numpy<1.17',
         'Pillow<7.0.0',
-        'PyWavelets~=1.0.3',
+        'PyWavelets~=1.1.1',
         'tqdm',
         'scikit-learn',
         'matplotlib',


### PR DESCRIPTION
running pytest tests/test_hashing.py::test_find_duplicates_encoding_map_input
shows that PyWavelets 1.0.3 will stop working in python 3.9:

> DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated since Python 3.3,
and in 3.9 it will stop working from collections import Iterable

Updating PyWavelets to 1.1.1 fixes this.