### PR TITLE
Close figure after plotting to avoid figure overwrite

### DIFF
--- a/imagededup/utils/plotter.py
+++ b/imagededup/utils/plotter.py
@@ -69,6 +69,7 @@ def _plot_images(
         plt.savefig(outfile)
 
     plt.show()
+    plt.close()
 
 
 def _validate_args(


### PR DESCRIPTION
# WHAT
Refers to issue #100.
`plot_duplicates`, when used repeatedly in a loop (to plot duplicates for many images repeatedly), might lead to overwriting some wrong images in consecutive plots. The error doesn't seem to have reproducibility, but is a general observation with matplotlib.

# WHY
Wrong images should not be plotted as duplicates.

# HOW
Closing the plot after showing.

# CHANGES
- Addition of plt.close() to close images.
- No suitable test cases could be written to check the behaviour.