### PR TITLE
dev branch setup.py install failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     long_description=long_description,
     license='Apache 2.0',
     install_requires=[
-        'numpy<1.17',
+        'numpy~=1.19.2',
         'Pillow<7.0.0',
         'PyWavelets~=1.1.1',
         'tqdm',


### PR DESCRIPTION
## WHAT

In the current state, running
`python setup.py install` on dev fails with error:
`error: numpy 1.16.6 is installed but numpy~=1.19.2 is required by {'tensorflow'}`

## WHY
Since the release of tf 2.4.0-rc1 (yesterday), numpy requirements have changed to numpy~=1.19.2. 

## CHANGE
In this change, the numpy requirements has been changed to  `numpy~=1.19.2`. 
Alternatively, tensorflow<2.4 can also be set. (not sure which is the better choice)
