### PR TITLE
Fix broken cython brute force in Python 3.8. Solves #108 and #114.

### DIFF
--- a/imagededup/handlers/search/brute_force_cython.py
+++ b/imagededup/handlers/search/brute_force_cython.py
@@ -20,13 +20,6 @@ class BruteForceCython:
         self.distance_function = distance_function
         self.hash_dict = hash_dict  # database
 
-        brute_force_cython_ext.clear()
-
-        for filename, hash_val in self.hash_dict.items():
-            brute_force_cython_ext.add(
-                int(hash_val, 16), filename.encode('utf-8')
-            )  # cast hex hash_val to decimals for __builtin_popcountll function
-
     def search(self, query: str, tol: int = 10) -> Dict[str, int]:
         """
         Function for searching using brute force.
@@ -39,6 +32,12 @@ class BruteForceCython:
             List of tuples of the form [(valid_retrieval_filename1: distance), (valid_retrieval_filename2: distance)]
         """
 
+        filenames = []
+        hash_vals = []
+        for filename, hash_val in self.hash_dict.items():
+            filenames.append(filename.encode('utf-8'))
+            hash_vals.append(int(hash_val, 16))
+
         return brute_force_cython_ext.query(
-            int(query, 16), tol
+            filenames, hash_vals, int(query, 16), tol
         )  # cast hex hash_val to decimals for __builtin_popcountll function

--- a/imagededup/handlers/search/brute_force_cython_ext.pyx
+++ b/imagededup/handlers/search/brute_force_cython_ext.pyx
@@ -9,16 +9,10 @@ ctypedef unsigned long long ull
 cdef extern from 'builtin/builtin.h':
     int psnip_builtin_popcountll(unsigned long long) nogil
 
-cdef vector[string] all_filenames
-cdef vector[ull] all_hashes
-
-
-def add(ull hash_val, string filename):
-    all_hashes.push_back(hash_val)
-    all_filenames.push_back(filename)
-
-
-def query(ull query_hash_val, unsigned int maxdist):
+def query(vector[string] all_filenames,
+          vector[ull] all_hashes,
+          ull query_hash_val,
+          unsigned int maxdist):
     matches = []
     cdef unsigned int dist
     cdef string filename
@@ -34,12 +28,3 @@ def query(ull query_hash_val, unsigned int maxdist):
             matches.append((filename.decode('utf-8'), dist))
 
     return matches
-
-
-def clear():
-    all_hashes.clear()
-    all_filenames.clear()
-
-
-def size():
-    return all_hashes.size()


### PR DESCRIPTION
In Python 3.8, Cython behaves weirdly on Mac OS X which affects our Brute Force implementation. The problem is described in #108 in more detail. This PR will fix it.  