### PR TITLE
Remove numpy as an explicit dependency and ensure pip dependency resolver works as expected

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy<1.19
 Pillow<7.0.0
 PyWavelets~=1.1.1
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
     long_description=long_description,
     license='Apache 2.0',
     install_requires=[
-        'numpy~=1.19.2',
         'Pillow<7.0.0',
         'PyWavelets~=1.1.1',
         'tqdm',
@@ -121,6 +120,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],


### PR DESCRIPTION
### WHAT
Allow tensorflow to install appropriate numpy version and ensure that package can be installed without error using 2020-resolver that helps pip resolve dependencies from October 2020 onwards.

### WHY
- Depending upon the tensorflow version installed, specific numpy versions need to be available. Therefore, tensorflow should be allowed to install the appropriate version instead of any explicit numpy version mandated by the imagededup package.
- As per the [announcement](https://discuss.python.org/t/announcement-pip-20-2-release/4863), new versions of pip (October 2020 onwards) will resolve dependencies in a way different than before. So, it is required to ensure than pip installing the package with  `--use-feature=2020-resolver` works without issue.

### HOW
- Remove explicit numpy installation.
- Build package locally with `pip install . --use-feature=2020-resolver`

On the test system: `macOS Mojave 10.14.6, python 3.8, conda environment`, using above command leads to following explicit package versions(only packages explicitly imported within the codebase mentioned below):
```
numpy==1.18.5
Pillow==6.2.2
PyWavelets==1.1.1
scikit-learn==0.23.2
scipy==1.5.4
tensorflow==2.3.1
tqdm==4.53.0
```
All tests are passing with these changes.