### PR TITLE
Add pre-commit and isort for easier contributing

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+multi_line_output = 3
+include_trailing_comma = true
+force_sort_within_sections = true
+known_first_party = imagededup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+---
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.5.2
+    hooks:
+      - id: isort
+...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,9 @@ You may look through the [GitHub issues](https://github.com/idealo/image-dedup/i
 
 ## Pull Requests (PR)
 1. Fork the repository and create a new branch from the `dev` branch.
-2. For bug fixes, add new tests and for new features, please add changes to the documentation.
-3. Do a PR from your new branch to our `dev` branch of the original Imagededup repo.
+2. Install the pre-commit hooks with `pre-commit install`.
+3. For bug fixes, add new tests and for new features, please add changes to the documentation.
+4. Do a PR from your new branch to our `dev` branch of the original Imagededup repo.
 
 ## Documentation
 - Make sure any new function or class you introduce has proper docstrings.

--- a/imagededup/evaluation/evaluation.py
+++ b/imagededup/evaluation/evaluation.py
@@ -3,8 +3,8 @@ from typing import Dict
 
 from imagededup.handlers.metrics.classification import classification_metrics
 from imagededup.handlers.metrics.information_retrieval import (
-    mean_metric,
     get_all_metrics,
+    mean_metric,
 )
 from imagededup.utils.logger import return_logger
 

--- a/imagededup/handlers/metrics/classification.py
+++ b/imagededup/handlers/metrics/classification.py
@@ -2,13 +2,13 @@ import itertools
 from typing import Dict, List, Tuple
 
 import numpy as np
-
 from sklearn.metrics import (
     classification_report,
+    precision_recall_fscore_support,
     precision_score,
     recall_score,
-    precision_recall_fscore_support,
 )
+
 from imagededup.utils.logger import return_logger
 
 logger = return_logger(__name__)

--- a/imagededup/handlers/metrics/information_retrieval.py
+++ b/imagededup/handlers/metrics/information_retrieval.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, Dict, Union, Tuple
+from typing import Callable, Dict, Tuple, Union
 
 import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity

--- a/imagededup/methods/__init__.py
+++ b/imagededup/methods/__init__.py
@@ -1,2 +1,2 @@
-from .hashing import PHash, AHash, DHash, WHash
 from .cnn import CNN
+from .hashing import AHash, DHash, PHash, WHash

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -4,11 +4,11 @@ from typing import Dict, List, Optional, Union
 import numpy as np
 
 from imagededup.handlers.search.retrieval import get_cosine_similarity
-from imagededup.utils.general_utils import save_json, get_files_to_remove
+from imagededup.utils.general_utils import get_files_to_remove, save_json
 from imagededup.utils.image_utils import (
+    expand_image_array_cnn,
     load_image,
     preprocess_image,
-    expand_image_array_cnn,
 )
 from imagededup.utils.logger import return_logger
 
@@ -39,7 +39,11 @@ class CNN:
         Args:
             verbose: Display progress bar if True else disable it. Default value is True.
         """
-        from tensorflow.keras.applications.mobilenet import MobileNet, preprocess_input
+        from tensorflow.keras.applications.mobilenet import (
+            MobileNet,
+            preprocess_input,
+        )
+
         from imagededup.utils.data_generator import DataGenerator
 
         self.MobileNet = MobileNet

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -1,15 +1,23 @@
 import os
+from pathlib import Path, PurePath
 import sys
-from pathlib import PurePath, Path
 from typing import Dict, List, Optional
 
-import pywt
 import numpy as np
+import pywt
 from scipy.fftpack import dct
 
 from imagededup.handlers.search.retrieval import HashEval
-from imagededup.utils.general_utils import get_files_to_remove, save_json, parallelise
-from imagededup.utils.image_utils import load_image, preprocess_image, check_image_array_hash
+from imagededup.utils.general_utils import (
+    get_files_to_remove,
+    parallelise,
+    save_json,
+)
+from imagededup.utils.image_utils import (
+    check_image_array_hash,
+    load_image,
+    preprocess_image,
+)
 from imagededup.utils.logger import return_logger
 
 logger = return_logger(__name__)

--- a/imagededup/utils/data_generator.py
+++ b/imagededup/utils/data_generator.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath
-from typing import Tuple, List, Callable
+from typing import Callable, List, Tuple
 
 import numpy as np
 from tensorflow.keras.utils import Sequence

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -1,7 +1,9 @@
 import json
-import tqdm
-from multiprocessing import cpu_count, Pool
+from multiprocessing import Pool, cpu_count
 from typing import Callable, Dict, List
+
+import tqdm
+
 from imagededup.utils.logger import return_logger
 
 logger = return_logger(__name__)

--- a/imagededup/utils/image_utils.py
+++ b/imagededup/utils/image_utils.py
@@ -1,11 +1,10 @@
 from pathlib import PurePath
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
-import numpy as np
 from PIL import Image
+import numpy as np
 
 from imagededup.utils.logger import return_logger
-
 
 IMG_FORMATS = ['JPEG', 'PNG', 'BMP', 'MPO', 'PPM', 'TIFF', 'GIF']
 logger = return_logger(__name__)

--- a/imagededup/utils/plotter.py
+++ b/imagededup/utils/plotter.py
@@ -1,11 +1,11 @@
+from pathlib import Path, PurePath
+from typing import Dict, List, Union
+
+from PIL import Image
+from matplotlib import figure
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
-from matplotlib import figure
-from pathlib import Path, PurePath
-from typing import Dict, Union, List
-
 import numpy as np
-from PIL import Image
 
 
 def _formatter(val: Union[int, np.float32]):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import sys
-from setuptools import setup, find_packages, Extension
+
+from setuptools import Extension, find_packages, setup
 
 long_description = '''
 imagededup is a python package that provides functionality to find duplicates in a collection of images using a variety
@@ -106,7 +107,7 @@ setup(
     extras_require={
         'tests': ['pytest', 'pytest-cov', 'pytest-mock', 'codecov'],
         'docs': ['mkdocs', 'mkdocs-material'],
-        'dev': ['bumpversion', 'twine'],
+        'dev': ['bumpversion', 'pre-commit', 'twine'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_bktree.py
+++ b/tests/test_bktree.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
-from imagededup.methods.hashing import Hashing
 from imagededup.handlers.search.bktree import BKTree, BkTreeNode
+from imagededup.methods.hashing import Hashing
 
 # Test BkTreeNode
 

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -1,15 +1,14 @@
+import json
+import os
 from pathlib import Path
 
-import os
-import json
-import numpy as np
 from PIL import Image
+import numpy as np
 import pytest
 from tensorflow.keras.models import Model
 
 from imagededup.methods.cnn import CNN
-from imagededup.utils.image_utils import load_image, expand_image_array_cnn
-
+from imagededup.utils.image_utils import expand_image_array_cnn, load_image
 
 p = Path(__file__)
 TEST_IMAGE = p.parent / 'data' / 'base_images' / 'ukbench00120.jpg'

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -1,6 +1,6 @@
-import pytest
 from pathlib import Path
 
+import pytest
 from tensorflow.keras.applications.mobilenet import preprocess_input
 
 from imagededup.utils.data_generator import DataGenerator

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,11 +1,10 @@
+import numpy as np
 import pytest
 
-import numpy as np
-
 from imagededup.evaluation.evaluation import (
-    evaluate,
     _check_map_correctness,
     _transpose_checker,
+    evaluate,
 )
 
 

--- a/tests/test_general_utils.py
+++ b/tests/test_general_utils.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 import numpy as np
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,12 +1,12 @@
 import os
-import sys
 from pathlib import Path
+import sys
+
 from PIL import Image
-
-import pytest
 import numpy as np
+import pytest
 
-from imagededup.methods.hashing import Hashing, PHash, DHash, AHash, WHash
+from imagededup.methods.hashing import AHash, DHash, Hashing, PHash, WHash
 
 p = Path(__file__)
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -1,17 +1,17 @@
-import pytest
 from pathlib import Path
 
-import numpy as np
 from PIL import Image
+import numpy as np
+import pytest
 
 from imagededup.utils.image_utils import (
-    preprocess_image,
-    load_image,
-    _check_3_dim,
     _add_third_dim,
+    _check_3_dim,
     _raise_wrong_dim_value_error,
     check_image_array_hash,
     expand_image_array_cnn,
+    load_image,
+    preprocess_image,
 )
 
 p = Path(__file__)

--- a/tests/test_information_retrieval.py
+++ b/tests/test_information_retrieval.py
@@ -1,6 +1,7 @@
-import pickle
-import pytest
 from pathlib import Path
+import pickle
+
+import pytest
 
 from imagededup.handlers.metrics.information_retrieval import *
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,11 +1,15 @@
 import os
-import pytest
-import matplotlib.pyplot as plt
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
-from imagededup.utils.plotter import _formatter, _validate_args, plot_duplicates
+from imagededup.utils.plotter import (
+    _formatter,
+    _validate_args,
+    plot_duplicates,
+)
 
 p = Path(__file__)
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,6 +1,7 @@
 import sys
-import pytest
+
 import numpy as np
+import pytest
 from sklearn.metrics.pairwise import cosine_similarity
 
 from imagededup.handlers.search.retrieval import (


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) makes automatically running checks (linting, isort, tests, ...) on commit easy. I've only added an isort hook in this PR, but many more are available.

[isort](https://pycqa.github.io/isort/) automatically sorts the imports according to configurable rules. I think I've added the rules that most closely following the current guidelines. There is some configurability possible if you would like it behave differently.

IMO [Black](https://github.com/psf/black) is also really worth looking into. It automates away all the formatting for you so you don't have to worry about that. Many Python projects are switching to it.

I think these could make helping new contributors to quickly and easily adhere to the contributor guidelines.

Of course, if you don't like any of this just close this PR. I just thought it could make development a bit easier by automating some of the boring work.