### PR TITLE
Modify tests to ignore hidden files

### DIFF
--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -109,7 +109,7 @@ def test_recursive_image_files():
     assert len(generator2.valid_image_files) == 6
 
     assert generator2.valid_image_files == sorted(
-        [x for x in NESTED_IMAGE_DIR.glob('**/*') if x.is_file()]
+        [x for x in NESTED_IMAGE_DIR.glob('**/*') if x.is_file() and not x.name.startswith('.')]
     )
 
 
@@ -124,5 +124,5 @@ def test_recursive_disabled_by_default():
     assert len(generator.valid_image_files) == 2
 
     assert generator.valid_image_files == sorted(
-        [x for x in NESTED_IMAGE_DIR.glob('*') if x.is_file()]
+        [x for x in NESTED_IMAGE_DIR.glob('*') if x.is_file() and not x.name.startswith('.')]
     )


### PR DESCRIPTION
## WHAT

Following two tests were failing (locally) as they didn't account for .DS_Store file on mac:
1. test_data_generator.py/test_recursive_image_files
2. test_data_generator.py/test_recursive_disabled_by_default

## FIX

 Modify tests to ignore hidden files '.DS_Store' that are automatically created on mac by the Finder application.