### PR TITLE
Fix/installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
     license='Apache 2.0',
     install_requires=[
         'tensorflow>1.0',
+        'numpy<1.20',
         'Pillow<7.0.0',
         'tqdm',
         'scikit-learn',


### PR DESCRIPTION
Running python setup.py install on the dev branch fails.

Tensorflow and numpy aren't playing well with each other. Leave tf>1.0 in setup.py with no mention of numpy (i.e., relying on tf to get numpy) leads to an error since tf 2.4.1 gets installed along with numpy 1.20.1 (due to pip resolver algo), but tf 2.4.1 needs numpy=~1.9.2. Explicitly mentioning numpy <1.20.0, makes the installation work. Additionally, newer versions of numpy (1.20.1), scipy (1.6 onwards) and matplotlib do not support python 3.6 anymore. The changes proposed in this PR will also work from Python 3.7 onwards.