### PR TITLE
remove old TF installation in cifar10_dup notebook

### DIFF
--- a/examples/CIFAR10_duplicates.ipynb
+++ b/examples/CIFAR10_duplicates.ipynb
@@ -53,11 +53,7 @@
       },
       "source": [
         "# install imagededup via PyPI\n",
-        "!pip install imagededup\n",
-        "\n",
-        "# by default imagededup is shipped with CPU-only support for TF but let's install GPU since we have it on Google Colab\n",
-        "# finding duplicates with Convolutional Neural Network (CNN) is much faster on GPU\n",
-        "!pip install tensorflow-gpu==2.0.0"
+        "!pip install imagededup"
       ],
       "execution_count": 1,
       "outputs": [
@@ -294,9 +290,11 @@
         "  if k in filenames_test:\n",
         "    tmp = [i for i in v if i in filenames_test]\n",
         "    duplicates_test[k] = tmp\n",
-        "    \n",
+        "\n",
         "# sort in descending order of duplicates\n",
-        "duplicates_test = {k: v for k, v in sorted(duplicates_test.items(), key=lambda x: len(x[1]), reverse=True)}"
+        "duplicates_test = {k: v for k, v in sorted(duplicates_test.items(),\n",
+        "                                           key=lambda x: len(x[1]),\n",
+        "                                           reverse=True)}"
       ],
       "execution_count": 0,
       "outputs": []
@@ -442,10 +440,11 @@
         "  if k in filenames_train:\n",
         "    tmp = [i for i in v if i in filenames_train]\n",
         "    duplicates_train[k] = tmp\n",
-        "    \n",
         "\n",
         "# sort in descending order of duplicates\n",
-        "duplicates_train = {k: v for k, v in sorted(duplicates_train.items(), key=lambda x: len(x[1]), reverse=True)}"
+        "duplicates_train = {k: v for k, v in sorted(duplicates_train.items(),\n",
+        "                                            key=lambda x: len(x[1]),\n",
+        "                                            reverse=True)}"
       ],
       "execution_count": 0,
       "outputs": []
@@ -589,9 +588,11 @@
         "    if k in filenames_test:\n",
         "        tmp = [i for i in v if i in filenames_train]\n",
         "        duplicates_test_train[k] = tmp\n",
-        "    \n",
+        "\n",
         "# sort in descending order of duplicates\n",
-        "duplicates_test_train = {k: v for k, v in sorted(duplicates_test_train.items(), key=lambda x: len(x[1]), reverse=True)}"
+        "duplicates_test_train = {k: v for k, v in sorted(duplicates_test_train.items(),\n",
+        "                                                 key=lambda x: len(x[1]),\n",
+        "                                                 reverse=True)}"
       ],
       "execution_count": 0,
       "outputs": []
@@ -709,19 +710,6 @@
           }
         }
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "zCMba_TEflGZ",
-        "colab": {}
-      },
-      "source": [
-        ""
-      ],
-      "execution_count": 0,
-      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
Hi.
With old TF installation, next error raises:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/36787333/145678476-0ed310e9-f81c-4af1-8bb8-dee7e3ee51e6.png">

So, remove it. Currently, default colab env goes with built-in gpu support.