### PR TITLE
configure number of processes for encode_images

### DIFF
--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -2,6 +2,7 @@ import os
 import sys
 import warnings
 
+from multiprocessing import cpu_count
 from pathlib import PurePath, Path
 from typing import Dict, List, Optional
 
@@ -130,7 +131,7 @@ class Hashing:
 
         return self._hash_func(image_pp) if isinstance(image_pp, np.ndarray) else None
 
-    def encode_images(self, image_dir=None, recursive=False):
+    def encode_images(self, image_dir=None, recursive=False, processes=cpu_count()):
         """
         Generate hashes for all images in a given directory of images.
 
@@ -156,7 +157,7 @@ class Hashing:
 
         logger.info(f'Start: Calculating hashes...')
 
-        hashes = parallelise(self.encode_image, files, self.verbose)
+        hashes = parallelise(self.encode_image, files, self.verbose, processes)
         hash_initial_dict = dict(zip(generate_relative_names(image_dir, files), hashes))
         hash_dict = {
             k: v for k, v in hash_initial_dict.items() if v

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -60,8 +60,8 @@ def save_json(results: Dict, filename: str, float_scores: bool = False) -> None:
     logger.info('End: Saving duplicates as json!')
 
 
-def parallelise(function: Callable, data: List, verbose: bool) -> List:
-    pool = Pool(processes=cpu_count())
+def parallelise(function: Callable, data: List, verbose: bool, processes: int=cpu_count()) -> List:
+    pool = Pool(processes=processes)
     results = list(
         tqdm.tqdm(pool.imap(function, data, 100), total=len(data), disable=not verbose)
     )


### PR DESCRIPTION
A way to configure the number of processes for encode_images, this way my pc can stay usable while I'm running imagededup in the background.

I'm not sure if it also makes sense to add this option to the `get_cosine_similarity` function?

PS it seems to me that this project is kind of inactive, maybe more maintainers are needed?