### PR TITLE
Port CNN to pytorch, other major changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
+os:
+  - linux
+  - osx
+  - windows
 python:
-  - 3.6
+  - 3.10
 install:
   - pip install "cython>=0.29"
   - pip install -e ".[tests, docs]"

--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ There are two ways to install imagededup:
 pip install imagededup
 ```
 
-> ⚠️ **Note**: The TensorFlow >=2.1 and TensorFlow 1.15 release now include GPU support by default.
-> Before that CPU and GPU packages are separate. If you have GPUs, you should rather
-> install the TensorFlow version with GPU support especially when you use CNN to find duplicates.
-> It's way faster. See the [TensorFlow guide](https://www.tensorflow.org/install/gpu) for more
-> details on how to install it for older versions of TensorFlow.
-
 * Install imagededup from the GitHub source:
 
 ```bash
@@ -128,6 +122,8 @@ repository.
 For more detailed usage of the package functionality, refer: [https://idealo.github.io/imagededup/](https://idealo.github.io/imagededup/)
 
 ## ⏳ Benchmarks
+**Update**: Provided benchmarks are only valid upto `imagededup v0.2.2`. The next releases have significant changes to all methods, so the current benchmarks may not hold.
+
 Detailed benchmarks on speed and classification metrics for different methods have been provided in the [documentation](https://idealo.github.io/imagededup/user_guide/benchmarks/).
 Generally speaking, following conclusions can be made:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,33 +16,33 @@ jobs:
   - job: 'Test'
     strategy:
       matrix:
-        Python36Linux:
-          imageName: 'ubuntu-16.04'
-          python.version: '3.6'
-        Python36Windows:
-          imageName: 'vs2017-win2016'
-          python.version: '3.6'
-        Python36Mac:
-          imageName: 'macos-10.14'
-          python.version: '3.6'
-        Python37Linux:
-          imageName: 'ubuntu-16.04'
-          python.version: '3.7'
-        Python37Windows:
-          imageName: 'vs2017-win2016'
-          python.version: '3.7'
-        Python37Mac:
-          imageName: 'macos-10.14'
-          python.version: '3.7'
         Python38Linux:
-          imageName: 'ubuntu-16.04'
+          imageName: 'ubuntu-latest'
           python.version: '3.8'
         Python38Windows:
-          imageName: 'vs2017-win2016'
+          imageName: 'windows-latest'
           python.version: '3.8'
         Python38Mac:
-          imageName: 'macos-10.14'
+          imageName: 'macOS-latest'
           python.version: '3.8'
+        Python39Linux:
+          imageName: 'ubuntu-latest'
+          python.version: '3.9'
+        Python39Windows:
+          imageName: 'windows-latest'
+          python.version: '3.9'
+        Python39Mac:
+          imageName: 'macOS-latest'
+          python.version: '3.9'
+        Python310Linux:
+          imageName: 'ubuntu-latest'
+          python.version: '3.10'
+        Python310Windows:
+          imageName: 'windows-latest'
+          python.version: '3.10'
+        Python310Mac:
+          imageName: 'macOS-latest'
+          python.version: '3.10'
       maxParallel: 2
     pool:
       vmImage: $(imageName)

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -41,9 +41,8 @@ class CNN:
 
     def __init__(self, verbose: bool = True) -> None:
         """
-        Initialize a keras MobileNet model that is sliced at the last convolutional layer.
-        Set the batch size for keras generators to be 64 samples. Set the input image size to (224, 224) for providing
-        as input to MobileNet model.
+        Initialize a pytorch MobileNet model v3 that is sliced at the last convolutional layer.
+        Set the batch size for pytorch dataloader to be 64 samples.
 
         Args:
             verbose: Display progress bar if True else disable it. Default value is True.
@@ -59,7 +58,7 @@ class CNN:
 
     def _build_model(self):
         """
-        Build MobileNet model sliced at the last convolutional layer with global average pooling added.
+        Build MobileNet v3 model sliced at the last convolutional layer with global average pooling added. Also initialize the corresponding preprocessing transform.
         """
         self.model = MobilenetV3()
         self.logger.info(

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -77,7 +77,7 @@ class CNN:
             ]
         )
 
-    def apply_mobilenetnet_preprocess(self, im_arr: np.array) -> torch.tensor:
+    def apply_mobilenet_preprocess(self, im_arr: np.array) -> torch.tensor:
         image_pil = Image.fromarray(im_arr)
         return self.transform(image_pil)
 
@@ -91,7 +91,7 @@ class CNN:
         Returns:
             Encodings for the image in the form of numpy array.
         """
-        image_pp = self.apply_mobilenetnet_preprocess(image_array)
+        image_pp = self.apply_mobilenet_preprocess(image_array)
         image_pp = image_pp.unsqueeze(0)
         img_features_tensor = self.model(image_pp)
         return img_features_tensor.detach().numpy()[..., 0, 0]
@@ -112,7 +112,7 @@ class CNN:
         self.dataloader = img_dataloader(
             image_dir=image_dir,
             batch_size=self.batch_size,
-            basenet_preprocess=self.apply_mobilenetnet_preprocess,
+            basenet_preprocess=self.apply_mobilenet_preprocess,
             recursive=recursive,
         )
 

--- a/imagededup/utils/data_generator.py
+++ b/imagededup/utils/data_generator.py
@@ -1,9 +1,8 @@
 from pathlib import PurePath
 from typing import Tuple, List, Callable, Optional
 
-import numpy as np
 import torch
-from PIL.Image import Image
+from PIL import Image
 from torch.utils.data import Dataset, DataLoader
 from torchvision import models
 from torchvision.transforms import transforms
@@ -13,16 +12,27 @@ from imagededup.utils.general_utils import generate_files
 
 
 class ImgDataset(Dataset):
-    def __init__(self, image_dir: PurePath, target_size: Tuple[int, int], recursive: Optional[bool]) -> None:
+    def __init__(
+        self,
+        image_dir: PurePath,
+        target_size: Tuple[int, int],
+        recursive: Optional[bool],
+    ) -> None:
         self.image_dir = image_dir
         self.target_size = target_size
         self.recursive = recursive
 
-        self.transform = transforms.Compose([transforms.Resize(target_size),
-                                             transforms.CenterCrop(224),
-                                             transforms.ToTensor(),
-                                             transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                                                  std=[0.229, 0.224, 0.225])])
+        self.transform = transforms.Compose(
+            [
+                transforms.Resize(target_size),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406],
+                    std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
 
         self.image_files = sorted(
             generate_files(self.image_dir, self.recursive)
@@ -60,114 +70,28 @@ def _collate_fn(batch):
     return torch.stack(ims), filenames, bad_images
 
 
-def img_dataloader(image_dir: PurePath, batch_size: int, target_size: Tuple[int, int], recursive: Optional[bool]):
-    img_dataset = ImgDataset(image_dir=image_dir, target_size=target_size, recursive=recursive)
-    return DataLoader(dataset=img_dataset, batch_size=batch_size, collate_fn=_collate_fn)
+def img_dataloader(
+    image_dir: PurePath,
+    batch_size: int,
+    target_size: Tuple[int, int],
+    recursive: Optional[bool],
+):
+    img_dataset = ImgDataset(
+        image_dir=image_dir, target_size=target_size, recursive=recursive
+    )
+    return DataLoader(
+        dataset=img_dataset, batch_size=batch_size, collate_fn=_collate_fn
+    )
 
 
 class MobilenetV3(torch.nn.Module):
     def __init__(self):
         super().__init__()
         mobilenet = models.mobilenet_v3_small(pretrained=True).eval()
-        self.mobilenet_gap_op = torch.nn.Sequential(mobilenet.features, mobilenet.avgpool)
+        self.mobilenet_gap_op = torch.nn.Sequential(
+            mobilenet.features, mobilenet.avgpool
+        )
 
     def forward(self, x):
         return self.mobilenet_gap_op(x)
 
-
-def generate_features(dataloader, model):
-    feat_arr = []
-    all_filenames = []
-
-    for ims, filenames, bad_images in dataloader:
-        arr = model(ims)
-        feat_arr.extend(arr[:2])
-        all_filenames.extend(filenames)
-    
-    if len(bad_images):
-        print('Found some bad images, ignoring for encoding generation ..')
-
-    feat_arr = torch.stack(feat_arr).squeeze()
-    valid_filenames = [filename for filename in all_filenames if filename]
-    return feat_arr, valid_filenames
-
-
-class DataGenerator(Sequence):
-    """Class inherits from Keras Sequence base object, allows to use multiprocessing in .fit_generator.
-
-    Attributes:
-        image_dir: Path of image directory.
-        batch_size: Number of images per batch.
-        basenet_preprocess: Basenet specific preprocessing function.
-        target_size: Dimensions that images get resized into when loaded.
-        recursive: Optional, find images recursively in the image directory.
-    """
-
-    def __init__(
-        self,
-        image_dir: PurePath,
-        batch_size: int,
-        basenet_preprocess: Callable,
-        target_size: Tuple[int, int],
-        recursive: Optional[bool] = False,
-    ) -> None:
-        """Init DataGenerator object.
-        """
-        self.image_dir = image_dir
-        self.batch_size = batch_size
-        self.basenet_preprocess = basenet_preprocess
-        self.target_size = target_size
-        self.recursive = recursive
-
-        self._get_image_files()
-        self.indexes = np.arange(len(self.image_files))
-        self.valid_image_files = self.image_files
-
-    def _get_image_files(self) -> None:
-        self.image_files = sorted(
-            generate_files(self.image_dir, self.recursive)
-        )  # ignore hidden files
-
-    def __len__(self) -> int:
-        """Number of batches in the Sequence."""
-        return int(np.ceil(len(self.image_files) / self.batch_size))
-
-    def __getitem__(self, index: int) -> Tuple[np.array, np.array]:
-        """Get batch at position `index`.
-        """
-        batch_indexes = self.indexes[
-                        index * self.batch_size: (index + 1) * self.batch_size
-                        ]
-        batch_samples = [self.image_files[i] for i in batch_indexes]
-        X = self._data_generator(batch_samples)
-        return X
-
-    def _data_generator(
-            self, image_files: List[PurePath]
-    ) -> Tuple[np.array, np.array]:
-        """Generate data from samples in specified batch."""
-        #  initialize images and labels tensors for faster processing
-        X = np.empty((len(image_files), *self.target_size, 3))
-
-        invalid_image_idx = []
-        for i, image_file in enumerate(image_files):
-            # load and randomly augment image
-            img = load_image(
-                image_file=image_file, target_size=self.target_size, grayscale=False
-            )
-
-            if img is not None:
-                X[i, :] = img
-
-            else:
-                invalid_image_idx.append(i)
-                self.valid_image_files = [_file for _file in self.valid_image_files if _file != image_file]
-
-        if invalid_image_idx:
-            X = np.delete(X, invalid_image_idx, axis=0)
-
-        # apply basenet specific preprocessing
-        # input is 4D numpy array of RGB values within [0, 255]
-        X = self.basenet_preprocess(X)
-
-        return X

--- a/imagededup/utils/data_generator.py
+++ b/imagededup/utils/data_generator.py
@@ -2,10 +2,94 @@ from pathlib import PurePath
 from typing import Tuple, List, Callable, Optional
 
 import numpy as np
-from tensorflow.keras.utils import Sequence
+import torch
+from PIL.Image import Image
+from torch.utils.data import Dataset, DataLoader
+from torchvision import models
+from torchvision.transforms import transforms
 
 from imagededup.utils.image_utils import load_image
 from imagededup.utils.general_utils import generate_files
+
+
+class ImgDataset(Dataset):
+    def __init__(self, image_dir: PurePath, target_size: Tuple[int, int], recursive: Optional[bool]) -> None:
+        self.image_dir = image_dir
+        self.target_size = target_size
+        self.recursive = recursive
+
+        self.transform = transforms.Compose([transforms.Resize(target_size),
+                                             transforms.CenterCrop(224),
+                                             transforms.ToTensor(),
+                                             transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                                                                  std=[0.229, 0.224, 0.225])])
+
+        self.image_files = sorted(
+            generate_files(self.image_dir, self.recursive)
+        )  # ignore hidden files
+
+    def __len__(self) -> int:
+        """Number of images."""
+        return len(self.image_files)
+
+    def __getitem__(self, item):
+        try:
+            img = Image.open(self.image_files[item])
+            if img.mode != 'RGB':
+                # convert to RGBA first to avoid warning
+                # we ignore alpha channel if available
+                img = img.convert('RGBA').convert('RGB')
+            img = self.transform(img)
+        except:
+            return {'image': None, 'filename': self.image_files[item]}
+        return {'image': img, 'filename': self.image_files[item]}
+
+
+def _collate_fn(batch):
+    ims = []
+    filenames = []
+    bad_images = []
+
+    for b in batch:
+        im = b['image']
+        if im is not None:
+            ims.append(im)
+            filenames.append(b['filename'])
+        else:
+            bad_images.append(b['filename'])
+    return torch.stack(ims), filenames, bad_images
+
+
+def img_dataloader(image_dir: PurePath, batch_size: int, target_size: Tuple[int, int], recursive: Optional[bool]):
+    img_dataset = ImgDataset(image_dir=image_dir, target_size=target_size, recursive=recursive)
+    return DataLoader(dataset=img_dataset, batch_size=batch_size, collate_fn=_collate_fn)
+
+
+class MobilenetV3(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        mobilenet = models.mobilenet_v3_small(pretrained=True).eval()
+        self.mobilenet_gap_op = torch.nn.Sequential(mobilenet.features, mobilenet.avgpool)
+
+    def forward(self, x):
+        return self.mobilenet_gap_op(x)
+
+
+def generate_features(dataloader, model):
+    feat_arr = []
+    all_filenames = []
+
+    for ims, filenames, bad_images in dataloader:
+        arr = model(ims)
+        feat_arr.extend(arr[:2])
+        all_filenames.extend(filenames)
+    
+    if len(bad_images):
+        print('Found some bad images, ignoring for encoding generation ..')
+
+    feat_arr = torch.stack(feat_arr).squeeze()
+    valid_filenames = [filename for filename in all_filenames if filename]
+    return feat_arr, valid_filenames
 
 
 class DataGenerator(Sequence):

--- a/imagededup/utils/image_utils.py
+++ b/imagededup/utils/image_utils.py
@@ -114,7 +114,7 @@ def preprocess_image(
         raise ValueError('Input is expected to be a numpy array or a pillow object!')
 
     if target_size:
-        image_pil = image_pil.resize(target_size, Image.ANTIALIAS)
+        image_pil = image_pil.resize(target_size, Image.LANCZOS)
 
     if grayscale:
         image_pil = image_pil.convert('L')

--- a/mkdocs/docs/examples/CIFAR10_deduplication.md
+++ b/mkdocs/docs/examples/CIFAR10_deduplication.md
@@ -91,5 +91,3 @@ duplicates_test_train = {k: v for k, v in sorted(duplicates_test_train.items(), 
 # plot duplicates found for some file
 plot_duplicates(image_dir=image_dir, duplicate_map=duplicates_test_train, filename=list(duplicates_test_train.keys())[0])
 ```
-
-For more examples, refer [this](https://github.com/idealo/imagededup/tree/master/examples) part of the repository. 

--- a/mkdocs/docs/user_guide/encoding_generation.md
+++ b/mkdocs/docs/user_guide/encoding_generation.md
@@ -25,7 +25,7 @@ where the returned variable *encodings* is a dictionary mapping image file names
 ```
 For hashing algorithms, the encodings are 64 bit hashes represented as 16 character hexadecimal strings.
 
-For cnn, the encodings are numpy array with shape (1, 1024).
+For cnn, the encodings are numpy array with shape (576,).
 
 The 'method-name' corresponds to one of the deduplication methods available and can be set to:
 
@@ -62,7 +62,7 @@ from imagededup.methods import <method-name>
 method_object = <method-name>()
 encoding = method_object.encode_image(image_file='path/to/image/file')
 ```
-where the returned variable *encoding* is either a hexadecimal string if a hashing method is used or a (1, 1024) numpy 
+where the returned variable *encoding* is either a hexadecimal string if a hashing method is used or a (576,) numpy 
 array if cnn is used.
 
 #### Options

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow>1.0
+torch>1.0
 Pillow<7.0.0
 tqdm
 scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-torch>1.0
-Pillow<7.0.0
+torch
+torchvision
+Pillow>=9.0
 tqdm
 scikit-learn
-PyWavelets~=1.1.1
+PyWavelets
 matplotlib
 # Development dependencies
 cython>=0.29

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     long_description=long_description,
     license='Apache 2.0',
     install_requires=[
-        'tensorflow>1.0',
+        'torch>1.0',
         'Pillow<7.0.0',
         'tqdm',
         'scikit-learn',

--- a/setup.py
+++ b/setup.py
@@ -96,11 +96,12 @@ setup(
     long_description=long_description,
     license='Apache 2.0',
     install_requires=[
-        'torch>1.0',
-        'Pillow<7.0.0',
+        'torch',
+        'torchvision',
+        'Pillow',
         'tqdm',
         'scikit-learn',
-        'PyWavelets~=1.1.1',
+        'PyWavelets',
         'matplotlib'
     ],
     extras_require={
@@ -121,6 +122,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ else:
 
 setup(
     name='imagededup',
-    version='0.2.4',
+    version='0.3.0',
     author='Tanuj Jain, Christopher Lennan, Zubin John, Dat Tran',
     author_email='tanuj.jain.10@gmail.com, christopherlennan@gmail.com, zrjohn@yahoo.com, datitran@gmail.com',
     description='Package for image deduplication',
@@ -98,7 +98,7 @@ setup(
     install_requires=[
         'torch',
         'torchvision',
-        'Pillow',
+        'Pillow>=9.0',
         'tqdm',
         'scikit-learn',
         'PyWavelets',
@@ -119,8 +119,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Cython',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -684,51 +684,6 @@ def test_find_duplicates_to_remove_encoding_integration(cnn):
     )
 
 
-# test verbose
-# def test_encode_images_verbose_true(capsys):
-#     cnn = CNN(verbose=True)
-#     cnn.encode_images(image_dir=TEST_IMAGE_DIR)
-#     out, err = capsys.readouterr()
-#     assert '[==============================]' in out
-#     assert '' == err
-
-
-# def test_encode_images_verbose_false(capsys):
-#     cnn = CNN(verbose=False)
-#     cnn.encode_images(image_dir=TEST_IMAGE_DIR)
-#     out, err = capsys.readouterr()
-#     assert '' == out
-#     assert '' == err
-
-
-# def test_find_duplicates_verbose_true(capsys):
-#     cnn = CNN(verbose=True)
-#     cnn.find_duplicates(
-#         image_dir=TEST_IMAGE_DIR,
-#         min_similarity_threshold=0.8,
-#         scores=False,
-#         outfile=False,
-#     )
-#     out, err = capsys.readouterr()
-#
-#     assert '[==============================]' in out
-#     assert '' == err
-#
-#
-# def test_find_duplicates_verbose_false(capsys):
-#     cnn = CNN(verbose=False)
-#     cnn.find_duplicates(
-#         image_dir=TEST_IMAGE_DIR,
-#         min_similarity_threshold=0.8,
-#         scores=False,
-#         outfile=False,
-#     )
-#     out, err = capsys.readouterr()
-#
-#     assert '' == out
-#     assert '' == err
-
-
 def test_scores_saving(cnn):
     save_file = 'myduplicates.json'
     cnn.find_duplicates(

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -518,26 +518,25 @@ def test_find_duplicates_to_remove_encoding_map(cnn, mocker, mocker_save_json):
 
 # test find_duplicates with directory path
 def test_find_duplicates_dir_integration(cnn):
-    # todo: replace the value of 0.98 with actual similarities
     expected_duplicates = {
         'ukbench00120.jpg': [
             ('ukbench00120_hflip.jpg', 0.9672552),
             ('ukbench00120_resize.jpg', 0.98120844),
-            ('ukbench00120_rotation.jpg', 0.98)
+            ('ukbench00120_rotation.jpg',  0.90708774)
         ],
         'ukbench00120_hflip.jpg': [
             ('ukbench00120.jpg', 0.9672552),
             ('ukbench00120_resize.jpg', 0.95676106),
-            ('ukbench00120_rotation.jpg', 0.98)
+            ('ukbench00120_rotation.jpg',  0.9030868)
         ],
         'ukbench00120_resize.jpg': [
             ('ukbench00120.jpg', 0.98120844),
             ('ukbench00120_hflip.jpg', 0.95676106),
-            ('ukbench00120_rotation.jpg', 0.98),
+            ('ukbench00120_rotation.jpg',  0.9102372),
         ],
-        'ukbench00120_rotation.jpg': [('ukbench00120.jpg', 0.98),
-                                      ('ukbench00120_hflip.jpg', 0.98),
-                                      ('ukbench00120_resize.jpg', 0.98)],
+        'ukbench00120_rotation.jpg': [('ukbench00120.jpg', 0.90708774),
+                                      ('ukbench00120_hflip.jpg', 0.9030868),
+                                      ('ukbench00120_resize.jpg',  0.9102372)],
         'ukbench09268.jpg': [],
     }
     duplicates = cnn.find_duplicates(
@@ -564,26 +563,25 @@ def test_find_duplicates_dir_integration(cnn):
 
 # test recursive find_duplicates with directory path
 def test_recursive_find_duplicates_dir_integration(cnn):
-    # todo: fix scores
     expected_duplicates = {
         str(Path('lvl1/ukbench00120.jpg')): [
-            ('ukbench00120_hflip.jpg', 0.9672552),
-            (str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')), 0.98120844),
-            (str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')), 0.98120844),
+            ('ukbench00120_hflip.jpg',  0.9891392),
+            (str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')), 0.99194086),
+            (str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')),  0.90708774),
         ],
         'ukbench00120_hflip.jpg': [
-            (str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')), 0.98120844),
-            (str(Path('lvl1/ukbench00120.jpg')), 0.9672552),
-            (str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')), 0.95676106),
+            (str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')), 0.9030868),
+            (str(Path('lvl1/ukbench00120.jpg')), 0.9891392),
+            (str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')),  0.9793916),
         ],
         str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')): [
-            (str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')), 0.98120844),
-            (str(Path('lvl1/ukbench00120.jpg')), 0.98120844),
-            ('ukbench00120_hflip.jpg', 0.95676106),
+            (str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')), 0.9102372),
+            (str(Path('lvl1/ukbench00120.jpg')), 0.99194086),
+            ('ukbench00120_hflip.jpg',  0.9793916),
         ],
-        str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')): [('ukbench00120_hflip.jpg', 0.95676106),
-                                                            (str(Path('lvl1/ukbench00120.jpg')), 0.98120844),
-                                                            (str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')), 0.98120844)],
+        str(Path('lvl1/lvl2a/ukbench00120_rotation.jpg')): [('ukbench00120_hflip.jpg',  0.9030868),
+                                                            (str(Path('lvl1/ukbench00120.jpg')), 0.90708774),
+                                                            (str(Path('lvl1/lvl2b/ukbench00120_resize.jpg')), 0.9102372)],
         str(Path('lvl1/lvl2b/ukbench09268.jpg')): [],
     }
     duplicates = cnn.find_duplicates(

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from tensorflow.keras.applications.mobilenet import preprocess_input
+# from tensorflow.keras.applications.mobilenet import preprocess_input
 
 from imagededup.utils.data_generator import DataGenerator
 

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -1,9 +1,10 @@
-import pytest
-from pathlib import Path
+from pathlib import Path, PurePath
+from typing import List, Tuple
 
-# from tensorflow.keras.applications.mobilenet import preprocess_input
+import torch
 
-from imagededup.utils.data_generator import DataGenerator
+from imagededup.methods import CNN
+from imagededup.utils.data_generator import img_dataloader
 
 p = Path(__file__)
 IMAGE_DIR = p.parent / 'data/base_images'
@@ -11,118 +12,52 @@ FORMATS_IMAGE_DIR = p.parent / 'data/formats_images'
 NESTED_IMAGE_DIR = p.parent / 'data/mixed_nested_images'
 
 TEST_BATCH_SIZE = 3
-TEST_TARGET_SIZE = (224, 224)
 
 
-@pytest.fixture(autouse=True)
-def run_before_tests():
-    global generator
-    generator = DataGenerator(
-        image_dir=IMAGE_DIR,
+def _init_dataloader(imdir: PurePath, recursive: bool) -> torch.utils.data.DataLoader:
+    cnn = CNN()
+    dataloader = img_dataloader(
+        image_dir=imdir,
         batch_size=TEST_BATCH_SIZE,
-        basenet_preprocess=preprocess_input,
-        target_size=TEST_TARGET_SIZE,
+        basenet_preprocess=cnn.apply_mobilenet_preprocess,
+        recursive=recursive,
     )
+    return dataloader
 
 
-def test__init():
-    assert generator.image_dir == IMAGE_DIR
-    assert generator.batch_size == TEST_BATCH_SIZE
-    assert generator.target_size == TEST_TARGET_SIZE
-    assert generator.basenet_preprocess == preprocess_input
+def _iterate_over_dataloader(dataloader: torch.utils.data.DataLoader) -> Tuple[List, List, List]:
+    all_filenames, ims_arr, all_bad_images = [], [], []
 
+    for ims, filenames, bad_images in dataloader:
+        ims_arr.extend(ims)
+        all_filenames.extend(filenames)
+        all_bad_images.extend(bad_images)
 
-def test__len():
-    assert generator.__len__() == 4
-
-
-def test__get_item(mocker):
-    mocker.patch.object(DataGenerator, '_data_generator')
-
-    generator.__getitem__(0)
-
-    generator._data_generator.assert_called_with(
-        [
-            IMAGE_DIR / 'ukbench00120.jpg',
-            IMAGE_DIR / 'ukbench01380.jpg',
-            IMAGE_DIR / 'ukbench08976.jpg',
-        ]
-    )
+    return all_filenames, ims_arr, all_bad_images
 
 
 def test__data_generator():
-    image_files = [
-        IMAGE_DIR / 'ukbench09348.jpg',
-        IMAGE_DIR / 'ukbench09012.jpg',
-        IMAGE_DIR / 'ukbench09380.jpg',
-    ]
-
-    result = generator._data_generator(image_files=image_files)
-
-    assert result.shape == tuple([TEST_BATCH_SIZE, *TEST_TARGET_SIZE, 3])
+    dataloader = _init_dataloader(imdir=IMAGE_DIR, recursive=False)
+    all_filenames, ims_arr, all_bad_images = _iterate_over_dataloader(dataloader)
+    all_ims = torch.stack(ims_arr)
+    assert all_ims.shape == tuple([10, 3, 224, 224])
+    assert len(all_filenames) == 10  # 10 images in the directory
+    assert len(all_bad_images) == 0
 
 
-def test_valid_image_files_1():
-    assert generator.valid_image_files == sorted(
-        [x for x in IMAGE_DIR.glob('*') if x.is_file()]
-    )
-
-
-def test_valid_image_files_2():
-    expected = [
-        FORMATS_IMAGE_DIR / 'baboon.pgm',
-        FORMATS_IMAGE_DIR / 'copyleft.tiff',
-        FORMATS_IMAGE_DIR / 'giphy.gif',
-        FORMATS_IMAGE_DIR / 'Iggy.1024.ppm',
-        FORMATS_IMAGE_DIR / 'marbles.pbm',
-        FORMATS_IMAGE_DIR / 'mpo_image.MPO',
-        FORMATS_IMAGE_DIR / 'ukbench09380.bmp',
-        FORMATS_IMAGE_DIR / 'ukbench09380.jpeg',
-        FORMATS_IMAGE_DIR / 'ukbench09380.png',
-        FORMATS_IMAGE_DIR / 'ukbench09380.svg',
-    ]
-
-    generator = DataGenerator(
-        image_dir=FORMATS_IMAGE_DIR,
-        batch_size=TEST_BATCH_SIZE,
-        basenet_preprocess=preprocess_input,
-        target_size=TEST_TARGET_SIZE,
-    )
-
-    generator.__getitem__(0)
-    generator.__getitem__(1)
-    generator.__getitem__(2)
-
-    # generator._update_valid_files()
-    assert sorted(generator.valid_image_files, key=lambda x: str(x).lower()) == expected
-
-
-def test_recursive_image_files():
-    generator2 = DataGenerator(
-        image_dir=NESTED_IMAGE_DIR,
-        batch_size=TEST_BATCH_SIZE,
-        basenet_preprocess=preprocess_input,
-        target_size=TEST_TARGET_SIZE,
-        recursive=True,
-    )
-
-    assert len(generator2.valid_image_files) == 6
-
-    assert generator2.valid_image_files == sorted(
-        [x for x in NESTED_IMAGE_DIR.glob('**/*') if x.is_file() and not x.name.startswith('.')]
-    )
+def test_recursive_true_and_corrupt_file_ignored():
+    dataloader = _init_dataloader(imdir=NESTED_IMAGE_DIR, recursive=True)
+    all_filenames, ims_arr, all_bad_images = _iterate_over_dataloader(dataloader)
+    all_ims = torch.stack(ims_arr)
+    assert all_ims.shape == tuple([5, 3, 224, 224])
+    assert len(all_filenames) == 5
+    assert len(all_bad_images) == 1
 
 
 def test_recursive_disabled_by_default():
-    generator = DataGenerator(
-        image_dir=NESTED_IMAGE_DIR,
-        batch_size=TEST_BATCH_SIZE,
-        basenet_preprocess=preprocess_input,
-        target_size=TEST_TARGET_SIZE,
-    )
-
-    assert len(generator.valid_image_files) == 2
-
-    assert generator.valid_image_files == sorted(
-        [x for x in NESTED_IMAGE_DIR.glob('*') if x.is_file() and not x.name.startswith('.')]
-    )
+    dataloader = _init_dataloader(imdir=NESTED_IMAGE_DIR, recursive=False)
+    all_filenames, ims_arr, all_bad_images = _iterate_over_dataloader(dataloader)
+    all_ims = torch.stack(ims_arr)
+    assert all_ims.shape == tuple([1, 3, 224, 224])
+    assert len(all_filenames) == 1
+    assert len(all_bad_images) == 1

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -636,7 +636,7 @@ def test_find_duplicates_correctness_score():
     duplicates = list(duplicate_dict.values())
     assert isinstance(duplicates[0], list)
     assert duplicate_dict['ukbench09268.jpg'] == []
-    assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 0)]  # todo:
+    assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 2)]
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='Does not run on Windows.')
@@ -660,7 +660,7 @@ def test_find_duplicates_clearing():
     duplicates = list(duplicate_dict.values())
     assert isinstance(duplicates[0], list)
     assert duplicate_dict['ukbench09268.jpg'] == []
-    assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 0)]
+    assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 2)]
 
 
 def test_find_duplicates_outfile():

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -175,6 +175,7 @@ def test_encode_images_accepts_valid_posixpath(hasher, mocker_encode_image):
 
 
 def test_encode_images_accepts_non_posixpath(hasher, mocker_encode_image):
+    print(PATH_IMAGE_DIR_STRING)
     assert len(hasher.encode_images(PATH_IMAGE_DIR_STRING)) == 6
 
 
@@ -595,7 +596,7 @@ def test_encode_images_return_non_none_hashes():
     [
         (phasher, '9fee256239984d71'),
         (dhasher, '2b69707551f1b87a'),
-        (ahasher, '81b8bc3c3c3c1e0a'),
+        (ahasher, '81b83c3c3c3c1e0a'),
         (whasher, '89b8bc3c3c3c5e0e'),
     ],
 )
@@ -635,7 +636,7 @@ def test_find_duplicates_correctness_score():
     duplicates = list(duplicate_dict.values())
     assert isinstance(duplicates[0], list)
     assert duplicate_dict['ukbench09268.jpg'] == []
-    assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 0)]
+    assert duplicate_dict['ukbench00120.jpg'] == [('ukbench00120_resize.jpg', 0)]  # todo:
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='Does not run on Windows.')


### PR DESCRIPTION
The Pull request comes with **major changes**.

## Supported Python versions

1. The support for `Python 3.6` has been **withdrawn** (Several major dependencies have withdrawn support for `Python 3.6`, including `scipy`, `Pillow-9.0+`, `matplotlib-3.6`)
2. `Python 3.7` will reach end-of-life on 2023-06-27. Hence, `Python 3.7` is also **not** supported.
3. **Python versions supported: 3.8+**.

## CNN
1. The underlying framework for CNN has been changed from `tensorflow` to **pytorch** (supported through `torchvision`).
2. The underlying CNN model is now a `MobilenetV3` instead of `Mobilenetv2`.
3. The size of embeddings generated by CNN is now **576** instead of 1024 (The embeddings remain robust).
4. Using GPU to generate encodings with CNN is currently not possible.

## Hashing
- Due to changes to the `resize` function of `Pillow` over several versions, the hashing methods do not yield the same hashes as the previous versions of imagededup (which forced `Pillow` version to be `<7.0.0`). This leads to different hashes being generated for the same image across different imagededup versions. (All hashing methods are impacted since they all rely upon Pillow's resizing method). The hashes work reliably, so there's no impact on the functionality per se.


### Todos after this PR has been merged

- Update example notebooks.
- Allow the use of GPU for using CNN methods.
- Update Benchmarks.
- Allow multiprocessing in pytorch dataloader.



