### PR TITLE
 Introducing new optional multiprocessing parameters

### DIFF
--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -20,7 +20,11 @@ def cosine_similarity_chunk(t: Tuple) -> np.ndarray:
 
 
 def get_cosine_similarity(
-    X: np.ndarray, verbose: bool = True, chunk_size: int = 1000, threshold: int = 10000, num_workers: int = 0
+    X: np.ndarray,
+    verbose: bool = True,
+    chunk_size: int = 1000,
+    threshold: int = 10000,
+    num_workers: int = 0,
 ) -> np.ndarray:
     n_rows = X.shape[0]
 
@@ -39,10 +43,13 @@ def get_cosine_similarity(
                 cosine_similarity_chunk,
                 [(X, idxs) for i, idxs in enumerate(zip(start_idxs, end_idxs))],
                 verbose,
-                num_workers
+                num_workers,
             )
         else:
-            cos_sim = tuple(cosine_similarity_chunk((X, idxs)) for idxs in tqdm(zip(start_idxs, end_idxs), total=len(start_idxs)))
+            cos_sim = tuple(
+                cosine_similarity_chunk((X, idxs))
+                for idxs in tqdm(zip(start_idxs, end_idxs), total=len(start_idxs))
+            )
         return np.vstack(cos_sim)
 
 
@@ -54,8 +61,10 @@ class HashEval:
         distance_function: Callable,
         verbose: bool = True,
         threshold: int = 5,
-        search_method: str = 'brute_force_cython' if not sys.platform == 'win32' else 'bktree',
-        num_dist_workers: int = cpu_count()
+        search_method: str = 'brute_force_cython'
+        if not sys.platform == 'win32'
+        else 'bktree',
+        num_dist_workers: int = cpu_count(),
     ) -> None:
         """
         Initialize a HashEval object which offers an interface to control hashing and search methods for desired
@@ -108,7 +117,9 @@ class HashEval:
                 [self.threshold] * len(self.queries),
             )
         )
-        result_map_list = parallelise(self._searcher, args, self.verbose, num_workers=self.num_dist_workers)
+        result_map_list = parallelise(
+            self._searcher, args, self.verbose, num_workers=self.num_dist_workers
+        )
         result_map = dict(zip(list(self.queries.keys()), result_map_list))
 
         self.query_results_map = {

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -1,3 +1,4 @@
+from multiprocessing import cpu_count
 import sys
 from typing import Callable, Dict, Union, Tuple
 
@@ -55,6 +56,7 @@ class HashEval:
         verbose: bool = True,
         threshold: int = 5,
         search_method: str = 'brute_force_cython' if not sys.platform == 'win32' else 'bktree',
+        num_dist_workers: int = cpu_count()
     ) -> None:
         """
         Initialize a HashEval object which offers an interface to control hashing and search methods for desired
@@ -66,6 +68,7 @@ class HashEval:
         self.verbose = verbose
         self.threshold = threshold
         self.query_results_map = None
+        self.num_dist_workers = num_dist_workers
 
         if search_method == 'bktree':
             self._fetch_nearest_neighbors_bktree()
@@ -106,7 +109,7 @@ class HashEval:
                 [self.threshold] * len(self.queries),
             )
         )
-        result_map_list = parallelise(self._searcher, args, self.verbose)
+        result_map_list = parallelise(self._searcher, args, self.verbose, num_workers=self.num_dist_workers)
         result_map = dict(zip(list(self.queries.keys()), result_map_list))
 
         self.query_results_map = {

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -42,8 +42,7 @@ def get_cosine_similarity(
                 num_workers
             )
         else:
-            cos_sim = tuple(cosine_similarity_chunk((X, idxs)) for idxs in zip(tqdm(start_idxs, end_idxs)))
-
+            cos_sim = tuple(cosine_similarity_chunk((X, idxs)) for idxs in tqdm(zip(start_idxs, end_idxs), total=len(start_idxs)))
         return np.vstack(cos_sim)
 
 

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Union, Tuple
 
 import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
+from tqdm import tqdm
 
 from imagededup.handlers.search.bktree import BKTree
 from imagededup.handlers.search.brute_force import BruteForce
@@ -14,11 +15,11 @@ logger = return_logger(__name__)
 
 
 def cosine_similarity_chunk(t: Tuple) -> np.ndarray:
-    return cosine_similarity(t[0][t[1][0] : t[1][1]], t[0]).astype('float16')
+    return cosine_similarity(t[0][t[1][0]: t[1][1]], t[0]).astype('float16')
 
 
 def get_cosine_similarity(
-    X: np.ndarray, verbose: bool = True, chunk_size: int = 1000, threshold: int = 10000
+    X: np.ndarray, verbose: bool = True, chunk_size: int = 1000, threshold: int = 10000, num_workers: int = 0
 ) -> np.ndarray:
     n_rows = X.shape[0]
 
@@ -31,11 +32,16 @@ def get_cosine_similarity(
         )
         start_idxs = list(range(0, n_rows, chunk_size))
         end_idxs = start_idxs[1:] + [n_rows]
-        cos_sim = parallelise(
-            cosine_similarity_chunk,
-            [(X, idxs) for i, idxs in enumerate(zip(start_idxs, end_idxs))],
-            verbose,
-        )
+
+        if num_workers > 0:
+            cos_sim = parallelise(
+                cosine_similarity_chunk,
+                [(X, idxs) for i, idxs in enumerate(zip(start_idxs, end_idxs))],
+                verbose,
+                num_workers
+            )
+        else:
+            cos_sim = tuple(cosine_similarity_chunk((X, idxs)) for idxs in zip(tqdm(start_idxs, end_idxs)))
 
         return np.vstack(cos_sim)
 

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -40,7 +40,7 @@ class CNN:
     methods are provided to accomplish these tasks.
     """
 
-    def __init__(self, verbose: bool = True, num_workers: int = cpu_count()) -> None:
+    def __init__(self, verbose: bool = True) -> None:
         """
         Initialize a pytorch MobileNet model v3 that is sliced at the last convolutional layer.
         Set the batch size for pytorch dataloader to be 64 samples.
@@ -57,7 +57,6 @@ class CNN:
         # directed to stdout (Don't know why that is the case)
         self._build_model()
         self.verbose = 1 if verbose is True else 0
-        self.num_workers = num_workers
 
     def _build_model(self):
         """
@@ -207,7 +206,7 @@ class CNN:
         )
 
     def encode_images(
-        self, image_dir: Union[PurePath, str], recursive: Optional[bool] = False
+        self, image_dir: Union[PurePath, str], recursive: Optional[bool] = False,
     ) -> Dict:
         """Generate CNN encodings for all images in a given directory of images.
 
@@ -255,6 +254,7 @@ class CNN:
         min_similarity_threshold: float,
         scores: bool,
         outfile: Optional[str] = None,
+        num_sim_workers: int = cpu_count()
     ) -> Dict:
         """
         Take in dictionary {filename: encoded image}, detects duplicates above the given cosine similarity threshold
@@ -282,7 +282,7 @@ class CNN:
 
         self.logger.info('Start: Calculating cosine similarities...')
 
-        self.cosine_scores = get_cosine_similarity(features, self.verbose, num_workers=self.num_workers)
+        self.cosine_scores = get_cosine_similarity(features, self.verbose, num_workers=num_sim_workers)
 
         np.fill_diagonal(
             self.cosine_scores, 2.0
@@ -316,6 +316,7 @@ class CNN:
         scores: bool,
         outfile: Optional[str] = None,
         recursive: Optional[bool] = False,
+        num_sim_workers: int = cpu_count()
     ) -> Dict:
         """
         Take in path of the directory in which duplicates are to be detected above the given threshold.
@@ -343,6 +344,7 @@ class CNN:
             min_similarity_threshold=min_similarity_threshold,
             scores=scores,
             outfile=outfile,
+            num_sim_workers=num_sim_workers
         )
 
     def find_duplicates(
@@ -353,6 +355,7 @@ class CNN:
         scores: bool = False,
         outfile: Optional[str] = None,
         recursive: Optional[bool] = False,
+        num_sim_workers: int = cpu_count()
     ) -> Dict:
         """
         Find duplicates for each file. Take in path of the directory or encoding dictionary in which duplicates are to
@@ -401,6 +404,7 @@ class CNN:
                 scores=scores,
                 outfile=outfile,
                 recursive=recursive,
+                num_sim_workers=num_sim_workers
             )
         elif encoding_map:
             if recursive:
@@ -413,6 +417,7 @@ class CNN:
                 min_similarity_threshold=min_similarity_threshold,
                 scores=scores,
                 outfile=outfile,
+                num_sim_workers=num_sim_workers
             )
 
         else:
@@ -427,6 +432,7 @@ class CNN:
         min_similarity_threshold: float = 0.9,
         outfile: Optional[str] = None,
         recursive: Optional[bool] = False,
+        num_sim_workers: int = cpu_count()
     ) -> List:
         """
         Give out a list of image file names to remove based on the similarity threshold. Does not remove the mentioned
@@ -466,6 +472,7 @@ class CNN:
                 min_similarity_threshold=min_similarity_threshold,
                 scores=False,
                 recursive=recursive,
+                num_sim_workers=num_sim_workers
             )
 
         files_to_remove = get_files_to_remove(duplicates)

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -230,9 +230,9 @@ class CNN:
         if not image_dir.is_dir():
             raise ValueError('Please provide a valid directory path!')
         
-        if num_enc_workers!=0 and sys.platform!='linux':
+        if num_enc_workers != 0 and sys.platform != 'linux':
             num_enc_workers = 0
-            self.logger.info(f'Setting num_enc_workers to 0, CNN encoding generation can only be parallelized on linux platform ..')
+            self.logger.info(f'Setting num_enc_workers to 0, CNN encoding generation parallelization support available on linux platform ..')
 
         return self._get_cnn_features_batch(image_dir=image_dir, recursive=recursive, num_workers=num_enc_workers)
 

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -48,7 +48,6 @@ class CNN:
 
         Args:
             verbose: Display progress bar if True else disable it. Default value is True.
-            num_workers: Number of cpu cores to use for multiprocessing functionality, set to number of number of logical cores in the system by default. Set to 0 to disable multiprocessing.
         """
         self.target_size = (256, 256)
         self.batch_size = 64
@@ -115,6 +114,7 @@ class CNN:
         Args:
             image_dir: Path to the image directory.
             recursive: Optional, find images recursively in a nested image directory structure.
+            num_workers: Optional, number of cpu cores to use for multiprocessing encoding generation (supported only on linux platform), set to 0 by default. 0 disables multiprocessing.
 
         Returns:
             A dictionary that contains a mapping of filenames and corresponding numpy array of CNN encodings.
@@ -215,6 +215,8 @@ class CNN:
         Args:
             image_dir: Path to the image directory.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation (supported only on linux platform), set to 0 by default. 0 disables multiprocessing.
+
         Returns:
             dictionary: Contains a mapping of filenames and corresponding numpy array of CNN encodings.
         Example:
@@ -271,6 +273,7 @@ class CNN:
             encoding_map: Dictionary with keys as file names and values as encoded images.
             min_similarity_threshold: Cosine similarity above which retrieved duplicates are valid.
             scores: Boolean indicating whether similarity scores are to be returned along with retrieved duplicates.
+            num_sim_workers: Optional, number of cpu cores to use for multiprocessing similarity computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -337,6 +340,8 @@ class CNN:
                     duplicates.
             outfile: Optional, name of the file the results should be written to.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation (supported only on linux platform), set to 0 by default. 0 disables multiprocessing.
+            num_sim_workers: Optional, number of cpu cores to use for multiprocessing similarity computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -381,6 +386,8 @@ class CNN:
                     duplicates.
             outfile: Optional, name of the file to save the results, must be a json. Default is None.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation (supported only on linux platform), set to 0 by default. 0 disables multiprocessing.
+            num_sim_workers: Optional, number of cpu cores to use for multiprocessing similarity computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             dictionary: if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -457,6 +464,8 @@ class CNN:
             min_similarity_threshold: Optional, threshold value (must be float between -1.0 and 1.0). Default is 0.9
             outfile: Optional, name of the file to save the results, must be a json. Default is None.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation (supported only on linux platform), set to 0 by default. 0 disables multiprocessing.
+            num_sim_workers: Optional, number of cpu cores to use for multiprocessing similarity computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             duplicates: List of image file names that should be removed.

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -157,7 +157,7 @@ class Hashing:
 
         logger.info(f'Start: Calculating hashes...')
 
-        hashes = parallelise(self.encode_image, files, self.verbose, num_workers=num_enc_workers)
+        hashes = parallelise(function=self.encode_image, data=files, verbose=self.verbose, num_workers=num_enc_workers)
         hash_initial_dict = dict(zip(generate_relative_names(image_dir, files), hashes))
         hash_dict = {
             k: v for k, v in hash_initial_dict.items() if v

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -309,6 +309,9 @@ class Hashing:
         elif encoding_map:
             if recursive:
                 warnings.warn('recursive parameter is irrelevant when using encodings.', SyntaxWarning)
+            
+            warnings.warn('Parameter num_enc_workers has no effect since encodings are already provided', RuntimeWarning)
+            
             result = self._find_duplicates_dict(
                 encoding_map=encoding_map,
                 max_distance_threshold=max_distance_threshold,
@@ -329,8 +332,8 @@ class Hashing:
         outfile: Optional[str] = None,
         search_method: str = 'brute_force_cython' if not sys.platform == 'win32' else 'bktree',
         recursive: Optional[bool] = False,
-        num_dist_workers: int = cpu_count(),
-        num_enc_workers: int = cpu_count()
+        num_enc_workers: int = cpu_count(),
+        num_dist_workers: int = cpu_count()
     ) -> Dict:
         """
         Take in path of the directory in which duplicates are to be detected below the given hamming distance

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -5,8 +5,9 @@ import warnings
 from pathlib import PurePath, Path
 from typing import Dict, List, Optional
 
-import pywt
+from multiprocessing import cpu_count
 import numpy as np
+import pywt
 from scipy.fftpack import dct
 
 from imagededup.handlers.search.retrieval import HashEval
@@ -47,7 +48,7 @@ class Hashing:
     methods are provided to accomplish these tasks.
     """
 
-    def __init__(self, verbose: bool = True) -> None:
+    def __init__(self, verbose: bool = True, num_workers: int = cpu_count()) -> None:
         """
         Initialize hashing class.
 
@@ -56,6 +57,7 @@ class Hashing:
         """
         self.target_size = (8, 8)  # resizing to dims
         self.verbose = verbose
+        self.num_workers = num_workers
 
     @staticmethod
     def hamming_distance(hash1: str, hash2: str) -> float:
@@ -156,7 +158,7 @@ class Hashing:
 
         logger.info(f'Start: Calculating hashes...')
 
-        hashes = parallelise(self.encode_image, files, self.verbose)
+        hashes = parallelise(self.encode_image, files, self.verbose, self.num_workers)
         hash_initial_dict = dict(zip(generate_relative_names(image_dir, files), hashes))
         hash_dict = {
             k: v for k, v in hash_initial_dict.items() if v

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -131,13 +131,14 @@ class Hashing:
 
         return self._hash_func(image_pp) if isinstance(image_pp, np.ndarray) else None
 
-    def encode_images(self, image_dir=None, recursive=False, num_enc_workers: int = cpu_count()):
+    def encode_images(self, image_dir=None, recursive: bool = False, num_enc_workers: int = cpu_count()):
         """
         Generate hashes for all images in a given directory of images.
 
         Args:
             image_dir: Path to the image directory.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             dictionary: A dictionary that contains a mapping of filenames and corresponding 64 character hash string
@@ -216,6 +217,7 @@ class Hashing:
             duplicates.
             outfile: Optional, name of the file to save the results. Default is None.
             search_method: Algorithm used to retrieve duplicates. Default is brute_force_cython for Unix else bktree.
+            num_dist_workers: Optional, number of cpu cores to use for multiprocessing distance computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -272,6 +274,8 @@ class Hashing:
             outfile: Optional, name of the file to save the results, must be a json. Default is None.
             search_method: Algorithm used to retrieve duplicates. Default is brute_force_cython for Unix else bktree.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation, set to number of CPUs in the system by default. 0 disables multiprocessing.
+            num_dist_workers: Optional, number of cpu cores to use for multiprocessing distance computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             duplicates dictionary: if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -347,6 +351,8 @@ class Hashing:
             outfile: Name of the file the results should be written to.
             search_method: Algorithm used to retrieve duplicates. Default is brute_force_cython for Unix else bktree.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation, set to number of CPUs in the system by default. 0 disables multiprocessing.
+            num_dist_workers: Optional, number of cpu cores to use for multiprocessing distance computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             if scores is True, then a dictionary of the form {'image1.jpg': [('image1_duplicate1.jpg',
@@ -388,6 +394,8 @@ class Hashing:
                                     valid. (must be an int between 0 and 64). Default is 10.
             outfile: Optional, name of the file to save the results, must be a json. Default is None.
             recursive: Optional, find images recursively in a nested image directory structure, set to False by default.
+            num_enc_workers: Optional, number of cpu cores to use for multiprocessing encoding generation, set to number of CPUs in the system by default. 0 disables multiprocessing.
+            num_dist_workers: Optional, number of cpu cores to use for multiprocessing distance computation, set to number of CPUs in the system by default. 0 disables multiprocessing.
 
         Returns:
             duplicates: List of image file names that are found to be duplicate of me other file in the directory.

--- a/imagededup/utils/data_generator.py
+++ b/imagededup/utils/data_generator.py
@@ -54,7 +54,7 @@ def img_dataloader(
     image_dir: PurePath,
     batch_size: int,
     basenet_preprocess: Callable[[np.array], torch.tensor],
-    recursive: Optional[bool],
+    recursive: Optional[bool]
 ) -> DataLoader:
     img_dataset = ImgDataset(
         image_dir=image_dir, basenet_preprocess=basenet_preprocess, recursive=recursive

--- a/imagededup/utils/data_generator.py
+++ b/imagededup/utils/data_generator.py
@@ -54,13 +54,14 @@ def img_dataloader(
     image_dir: PurePath,
     batch_size: int,
     basenet_preprocess: Callable[[np.array], torch.tensor],
-    recursive: Optional[bool]
+    recursive: Optional[bool],
+    num_workers: int
 ) -> DataLoader:
     img_dataset = ImgDataset(
         image_dir=image_dir, basenet_preprocess=basenet_preprocess, recursive=recursive
     )
     return DataLoader(
-        dataset=img_dataset, batch_size=batch_size, collate_fn=_collate_fn
+        dataset=img_dataset, batch_size=batch_size, collate_fn=_collate_fn, num_workers=num_workers
     )
 
 

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -1,5 +1,5 @@
 import json
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool
 from pathlib import Path, PurePath
 from typing import Callable, Dict, List, Union
 
@@ -60,8 +60,9 @@ def save_json(results: Dict, filename: str, float_scores: bool = False) -> None:
     logger.info('End: Saving duplicates as json!')
 
 
-def parallelise(function: Callable, data: List, verbose: bool) -> List:
-    pool = Pool(processes=cpu_count())
+def parallelise(function: Callable, data: List, verbose: bool, num_workers: int) -> List:
+    num_workers = 1 if num_workers < 1 else num_workers  # Pool needs to have at least 1 worker.
+    pool = Pool(processes=num_workers)
     results = list(
         tqdm.tqdm(pool.imap(function, data, 100), total=len(data), disable=not verbose)
     )

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -237,6 +237,7 @@ def test_encode_images(cnn):
         cnn.encode_images('abc')
 
 
+@pytest.mark.skipif(sys.platform == 'win32' or sys.platform == 'darwin', reason='CNN encoding parallelization not supported on Windows/mac.')
 def test_encode_images_num_workers(cnn, mocker):
     num_enc_workers = 4
     gen_batches_mocker = mocker.patch('imagededup.methods.cnn.CNN._get_cnn_features_batch')

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -530,6 +530,7 @@ def test_find_duplicates_dict_recursive_warning(cnn, mocker):
         num_sim_workers=cpu_count()
     )
 
+
 def test_find_duplicates_dict_num_enc_workers_warning(cnn, mocker):
     encoding_map = data_encoding_map()
     find_dup_dict_mocker = mocker.patch(

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -1,3 +1,4 @@
+from multiprocessing import cpu_count
 from pathlib import Path
 
 import os
@@ -317,6 +318,7 @@ def test__find_duplicates_dir(cnn, mocker):
     threshold = 0.8
     scores = True
     outfile = True
+    num_sim_workers = 2
     ret_val_find_dup_dict = {
         'filename1.jpg': [('dup1.jpg', 0.82)],
         'filename2.jpg': [('dup2.jpg', 0.90)],
@@ -332,6 +334,7 @@ def test__find_duplicates_dir(cnn, mocker):
         min_similarity_threshold=threshold,
         scores=scores,
         outfile=outfile,
+        num_sim_workers=num_sim_workers
     )
     encode_images_mocker.assert_called_once_with(image_dir=TEST_IMAGE_DIR, recursive=False)
     find_dup_dict_mocker.assert_called_once_with(
@@ -339,6 +342,7 @@ def test__find_duplicates_dir(cnn, mocker):
         min_similarity_threshold=threshold,
         scores=scores,
         outfile=outfile,
+        num_sim_workers=num_sim_workers
     )
 
 
@@ -349,6 +353,7 @@ def test_find_duplicates_dir(cnn, mocker):
     threshold = 0.9
     scores = True
     outfile = True
+    num_sim_workers = 2
     find_dup_dir_mocker = mocker.patch(
         'imagededup.methods.cnn.CNN._find_duplicates_dir'
     )
@@ -357,6 +362,7 @@ def test_find_duplicates_dir(cnn, mocker):
         min_similarity_threshold=threshold,
         outfile=outfile,
         scores=scores,
+        num_sim_workers=num_sim_workers
     )
     find_dup_dir_mocker.assert_called_once_with(
         image_dir=TEST_IMAGE_DIR,
@@ -364,6 +370,7 @@ def test_find_duplicates_dir(cnn, mocker):
         scores=scores,
         outfile=outfile,
         recursive=False,
+        num_sim_workers=num_sim_workers
     )
 
 
@@ -380,12 +387,38 @@ def test_find_duplicates_dict(cnn, mocker):
         min_similarity_threshold=threshold,
         outfile=outfile,
         scores=scores,
+        num_sim_workers=cpu_count()
     )
     find_dup_dict_mocker.assert_called_once_with(
         encoding_map=encoding_map,
         min_similarity_threshold=threshold,
         scores=scores,
         outfile=outfile,
+        num_sim_workers=cpu_count()
+    )
+
+
+def test_find_duplicates_dict_num_worker_has_impact(cnn, mocker):
+    encoding_map = data_encoding_map()
+    threshold = 0.9
+    scores = True
+    outfile = True
+    find_dup_dict_mocker = mocker.patch(
+        'imagededup.methods.cnn.CNN._find_duplicates_dict'
+    )
+    cnn.find_duplicates(
+        encoding_map=encoding_map,
+        min_similarity_threshold=threshold,
+        outfile=outfile,
+        scores=scores,
+        num_sim_workers=2
+    )
+    find_dup_dict_mocker.assert_called_once_with(
+        encoding_map=encoding_map,
+        min_similarity_threshold=threshold,
+        scores=scores,
+        outfile=outfile,
+        num_sim_workers=2
     )
 
 
@@ -410,6 +443,7 @@ def test_find_duplicates_dict_recursive_warning(cnn, mocker):
         min_similarity_threshold=threshold,
         scores=scores,
         outfile=outfile,
+        num_sim_workers=cpu_count()
     )
 
 
@@ -448,6 +482,7 @@ def test_find_duplicates_to_remove_outfile_false(cnn, mocker, mocker_save_json):
         min_similarity_threshold=threshold,
         scores=False,
         recursive=False,
+        num_sim_workers=cpu_count()
     )
     get_files_to_remove_mocker.assert_called_once_with(ret_val_find_dup_dict)
     mocker_save_json.assert_not_called()
@@ -478,6 +513,7 @@ def test_find_duplicates_to_remove_outfile_true(cnn, mocker, mocker_save_json):
         min_similarity_threshold=threshold,
         scores=False,
         recursive=False,
+        num_sim_workers=cpu_count()
     )
     get_files_to_remove_mocker.assert_called_once_with(ret_val_find_dup_dict)
     mocker_save_json.assert_called_once_with(ret_val_get_files_to_remove, outfile)
@@ -508,6 +544,7 @@ def test_find_duplicates_to_remove_encoding_map(cnn, mocker, mocker_save_json):
         min_similarity_threshold=threshold,
         scores=False,
         recursive=False,
+        num_sim_workers=cpu_count()
     )
     get_files_to_remove_mocker.assert_called_once_with(ret_val_find_dup_dict)
     mocker_save_json.assert_called_once_with(ret_val_get_files_to_remove, outfile)

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -21,6 +21,7 @@ def _init_dataloader(imdir: PurePath, recursive: bool) -> torch.utils.data.DataL
         batch_size=TEST_BATCH_SIZE,
         basenet_preprocess=cnn.apply_mobilenet_preprocess,
         recursive=recursive,
+        num_workers=0
     )
     return dataloader
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -285,6 +285,7 @@ def test__find_duplicates_dict_outfile_none(mocker):
     save_json_mocker.assert_not_called()
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Does not run on Windows.')
 def test__find_duplicates_dict_num_dist_workers_has_impact(mocker):
     encoding_map = {'1.jpg': '123456'}
     num_dist_workers = 2

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -181,11 +181,15 @@ def test_encode_images_accepts_non_posixpath(hasher, mocker_encode_image):
 
 
 def test_encode_images_finds_recursive(hasher, mocker_encode_image):
-    assert len(hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED, True)) == 6  # 6 files in total
+    assert (
+        len(hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED, True)) == 6
+    )  # 6 files in total
 
 
 def test_encode_images_finds_non_recursive(hasher, mocker_encode_image):
-    assert len(hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED)) == 2  # 2 files in the directory
+    assert (
+        len(hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED)) == 2
+    )  # 2 files in the directory
 
 
 def test_encode_images_rejects_non_directory_paths(hasher):
@@ -211,20 +215,30 @@ def test_recursive_on_flat_directory():
 def test_recursive_disabled_by_default():
     hasher = PHash()
     hashes = hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED)
-    hashes_non_recursive = hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED, recursive=False)
+    hashes_non_recursive = hasher.encode_images(
+        PATH_IMAGE_DIR_MIXED_NESTED, recursive=False
+    )
     assert hashes_non_recursive == hashes
 
 
-# from imagededup.utils.general_utils import parallelise
-# import unittest.mock as mock
-# parallelise = mock.create_autospec(parallelise)
-
-def test_encode_images_parallelise_with_num_workers(mocker):
+def test_encode_images_parallelise_with_num_workers(hasher, mocker):
     num_enc_workers = 8
     par_mock = mocker.patch('imagededup.methods.hashing.parallelise')
-    hasher = PHash()
-    hash = hasher.encode_images(PATH_IMAGE_DIR_MIXED_NESTED, num_enc_workers=num_enc_workers)
-    par_mock.assert_called_once_with(function=Hashing.encode_image, data=[], verbose=True, num_workers=num_enc_workers)
+    generate_files_mock = mocker.patch(
+        'imagededup.methods.hashing.generate_files', return_value=['1.jpg', '2.jpg']
+    )
+    generate_rel_names_mock = mocker.patch(
+        'imagededup.methods.hashing.generate_relative_names'
+    )
+    hash = hasher.encode_images(
+        PATH_IMAGE_DIR_MIXED_NESTED, num_enc_workers=num_enc_workers
+    )
+    par_mock.assert_called_once_with(
+        function=hasher.encode_image,
+        data=['1.jpg', '2.jpg'],
+        verbose=True,
+        num_workers=num_enc_workers,
+    )
 
 
 def test_hash_func(hasher, mocker):
@@ -265,7 +279,7 @@ def test__find_duplicates_dict_outfile_none(mocker):
         verbose=verbose,
         threshold=threshold,
         search_method='brute_force_cython',
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
     hasheval_mocker.return_value.retrieve_results.assert_called_once_with(scores=scores)
     save_json_mocker.assert_not_called()
@@ -279,8 +293,7 @@ def test__find_duplicates_dict_num_dist_workers_has_impact(mocker):
     hasheval_mocker = mocker.patch('imagededup.methods.hashing.HashEval')
 
     myhasher._find_duplicates_dict(
-        encoding_map=encoding_map,
-        num_dist_workers=num_dist_workers
+        encoding_map=encoding_map, num_dist_workers=num_dist_workers
     )
     hasheval_mocker.assert_called_with(
         test=encoding_map,
@@ -289,7 +302,7 @@ def test__find_duplicates_dict_num_dist_workers_has_impact(mocker):
         verbose=True,
         threshold=10,
         search_method='brute_force_cython',
-        num_dist_workers=num_dist_workers
+        num_dist_workers=num_dist_workers,
     )
 
 
@@ -314,7 +327,7 @@ def test__find_duplicates_dict_outfile_none_verbose(hasher, mocker):
         verbose=True,
         threshold=threshold,
         search_method='brute_force_cython',
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
     hasheval_mocker.return_value.retrieve_results.assert_called_once_with(scores=scores)
     save_json_mocker.assert_not_called()
@@ -346,7 +359,7 @@ def test__find_duplicates_dict_outfile_true(hasher, mocker):
         verbose=verbose,
         threshold=threshold,
         search_method='brute_force_cython',
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
     hasheval_mocker.return_value.retrieve_results.assert_called_once_with(scores=scores)
     save_json_mocker.assert_called_once_with(
@@ -381,14 +394,16 @@ def test__find_duplicates_dir(hasher, mocker):
         outfile=outfile,
         search_method='brute_force_cython',
     )
-    encode_images_mocker.assert_called_once_with(PATH_IMAGE_DIR, recursive=False, num_enc_workers=cpu_count())
+    encode_images_mocker.assert_called_once_with(
+        PATH_IMAGE_DIR, recursive=False, num_enc_workers=cpu_count()
+    )
     find_dup_dict_mocker.assert_called_once_with(
         encoding_map=encoding_map,
         max_distance_threshold=threshold,
         scores=scores,
         outfile=outfile,
         search_method='brute_force_cython',
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
 
 
@@ -426,7 +441,7 @@ def test_find_duplicates_dir(hasher, mocker, mocker_hamming_distance):
         search_method='brute_force_cython',
         recursive=False,
         num_enc_workers=cpu_count(),
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
 
 
@@ -441,7 +456,7 @@ def test_find_duplicates_dir_multiprocessing_has_impact(hasher, mocker):
     hasher.find_duplicates(
         image_dir=PATH_IMAGE_DIR,
         num_enc_workers=num_enc_workers,
-        num_dist_workers=num_dist_workers
+        num_dist_workers=num_dist_workers,
     )
     find_dup_dir_mocker.assert_called_once_with(
         image_dir=PATH_IMAGE_DIR,
@@ -451,7 +466,7 @@ def test_find_duplicates_dir_multiprocessing_has_impact(hasher, mocker):
         search_method='brute_force_cython',
         recursive=False,
         num_enc_workers=num_enc_workers,
-        num_dist_workers=num_dist_workers
+        num_dist_workers=num_dist_workers,
     )
 
 
@@ -478,7 +493,7 @@ def test_find_duplicates_dict(hasher, mocker, mocker_hamming_distance):
         scores=scores,
         outfile=outfile,
         search_method='brute_force_cython',
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
 
 
@@ -515,7 +530,7 @@ def test_find_duplicates_to_remove_outfile_false(hasher, mocker):
         scores=False,
         recursive=False,
         num_enc_workers=cpu_count(),
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
     get_files_to_remove_mocker.assert_called_once_with(ret_val_find_dup_dict)
     save_json_mocker.assert_not_called()
@@ -548,7 +563,7 @@ def test_find_duplicates_to_remove_outfile_true(hasher, mocker):
         scores=False,
         recursive=False,
         num_enc_workers=cpu_count(),
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
     get_files_to_remove_mocker.assert_called_once_with(ret_val_find_dup_dict)
     save_json_mocker.assert_called_once_with(ret_val_get_files_to_remove, outfile)
@@ -580,7 +595,7 @@ def test_find_duplicates_to_remove_encoding_map(hasher, mocker):
         scores=False,
         recursive=False,
         num_enc_workers=cpu_count(),
-        num_dist_workers=cpu_count()
+        num_dist_workers=cpu_count(),
     )
     get_files_to_remove_mocker.assert_called_once_with(ret_val_find_dup_dict)
     save_json_mocker.assert_not_called()
@@ -591,13 +606,11 @@ def test_find_duplicates_to_remove_multiprocessing_has_impact(hasher, mocker):
     num_enc_workers = 2
     num_dist_workers = 8
 
-    find_dup_mocker = mocker.patch(
-        'imagededup.methods.hashing.Hashing.find_duplicates'
-    )
+    find_dup_mocker = mocker.patch('imagededup.methods.hashing.Hashing.find_duplicates')
     hasher.find_duplicates_to_remove(
         image_dir=PATH_IMAGE_DIR,
         num_enc_workers=num_enc_workers,
-        num_dist_workers=num_dist_workers
+        num_dist_workers=num_dist_workers,
     )
     find_dup_mocker.assert_called_once_with(
         image_dir=PATH_IMAGE_DIR,
@@ -606,8 +619,9 @@ def test_find_duplicates_to_remove_multiprocessing_has_impact(hasher, mocker):
         scores=False,
         recursive=False,
         num_enc_workers=num_enc_workers,
-        num_dist_workers=num_dist_workers
+        num_dist_workers=num_dist_workers,
     )
+
 
 # Integration tests
 
@@ -806,9 +820,7 @@ def test_find_duplicates_encoding_map_recursive_warning():
     phasher = PHash()
     with pytest.warns(SyntaxWarning):
         duplicate_dict = phasher.find_duplicates(
-                encoding_map=encoding,
-                max_distance_threshold=10,
-                recursive=True
+            encoding_map=encoding, max_distance_threshold=10, recursive=True
         )
         assert isinstance(duplicate_dict, dict)
         assert isinstance(list(duplicate_dict.values())[0], list)
@@ -826,6 +838,7 @@ def test_find_duplicates_to_remove_dir():
     assert removal_list == ['ukbench00120.jpg'] or removal_list == [
         'ukbench00120_resize.jpg'
     ]
+
 
 def test_find_duplicates_to_remove_nested_dir():
     phasher = PHash()

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -829,6 +829,21 @@ def test_find_duplicates_encoding_map_recursive_warning():
         assert duplicate_dict['ukbench00120.jpg'] == ['ukbench00120_resize.jpg']
 
 
+def test_find_duplicates_dict_num_enc_workers_warning():
+    encoding = {
+        'ukbench00120_resize.jpg': '9fee256239984d71',
+        'ukbench00120_rotation.jpg': '850d513c4fdcbb72',
+        'ukbench00120.jpg': '9fee256239984d71',
+        'ukbench00120_hflip.jpg': 'cabb7237e8cd3824',
+        'ukbench09268.jpg': 'c73c36c2da2f29c9',
+    }
+    phasher = PHash()
+    with pytest.warns(RuntimeWarning):
+        duplicate_dict = phasher.find_duplicates(
+            encoding_map=encoding, max_distance_threshold=10, recursive=False, num_enc_workers=4
+        )
+
+
 def test_find_duplicates_to_remove_dir():
     phasher = PHash()
 


### PR DESCRIPTION
# WHAT/WHY
Introduces new optional multiprocessing parameters to several methods:
- `num_enc_workers` - Change number of processes to generate encodings  (Addresses #156)
- `num_sim_workers`/`num_dist_workers`  - Change number of processes to compute similarity/distances (Addresses #95, #113)

# HOW
## APIs impacted
For both CNN as well as Hashing functions, the following user-facing api calls get new parameters-
- `encode_images`
- `find_duplicates`
- `find_duplicates_to_remove`

## Choice of default values
- `num_enc_workers`: For CNN methods, this is set to 0 by default (0=disabled). **Furthermore, parallelization of CNN encoding generation is only supported on linux platform**. This is because pytorch requires the call to Dataloader to be wrapped within an `if ___name__ == '__main__'` construct to enable multiprocessing on non-linux platforms (due to the difference between `fork()` vs `spawn()` call used for multiprocessing on different systems). Such a construct does not fit well with the current code structure.
For Hashing methods, this parameter is set to the cpu count of the system. The default values preserve backward compatibility.
- `num_dist_workers`/`num_sim_workers`: Set to cpu count of the system. The default values preserve backward compatibility.
