### PR TITLE
Use torch.no_grad to reduce GPU memory consumption

### DIFF
--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -142,12 +142,13 @@ class CNN:
         feat_arr, all_filenames = [], []
         bad_im_count = 0
 
-        for ims, filenames, bad_images in self.dataloader:
-            arr = self.model(ims.to(self.device))
-            feat_arr.extend(arr)
-            all_filenames.extend(filenames)
-            if bad_images:
-                bad_im_count += 1
+        with torch.no_grad():
+            for ims, filenames, bad_images in self.dataloader:
+                arr = self.model(ims.to(self.device))
+                feat_arr.extend(arr)
+                all_filenames.extend(filenames)
+                if bad_images:
+                    bad_im_count += 1
 
         if bad_im_count:
             self.logger.info(


### PR DESCRIPTION
By default, PyTorch will store activations etc. for computing gradients. This will cause the CNN method to consume a large amount of GPU memory, ultimately causing GPU out-of-memory error when the dataset is large. 

This pull request adds `torch.no_grad` context manager to disable gradient calculation and reduce memory consumption when computing CNN features.