### PR TITLE
fix failing cnn and hashing tests due to use of pytest.warns(None)

### DIFF
--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 from PIL import Image
 import pytest
+import warnings
 from torchvision.transforms import transforms
 
 from imagededup.methods.cnn import CNN
@@ -891,7 +892,8 @@ def test_find_duplicates_encoding_integration(cnn):
     }
 
     encodings = cnn.encode_images(TEST_IMAGE_DIR_MIXED)
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         duplicates = cnn.find_duplicates(
             encoding_map=encodings, min_similarity_threshold=0.9, scores=True, outfile=False
         )

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -5,6 +5,7 @@ from PIL import Image
 
 from multiprocessing import cpu_count
 import pytest
+import warnings
 import numpy as np
 
 from imagededup.methods.hashing import Hashing, PHash, DHash, AHash, WHash
@@ -800,7 +801,8 @@ def test_find_duplicates_encoding_map_input():
         'ukbench09268.jpg': 'c73c36c2da2f29c9',
     }
     phasher = PHash()
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         duplicate_dict = phasher.find_duplicates(
             encoding_map=encoding, max_distance_threshold=10
         )


### PR DESCRIPTION
Tests fail on Python 3.11:

```
tests/test_cnn.py:894: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = WarningsChecker(record=True), expected_warning = None, match_expr = None

    def __init__(
        self,
        expected_warning: Union[Type[Warning], Tuple[Type[Warning], ...]] = Warning,
        match_expr: Optional[Union[str, Pattern[str]]] = None,
        *,
        _ispytest: bool = False,
    ) -> None:
        check_ispytest(_ispytest)
        super().__init__(_ispytest=True)
    
        msg = "exceptions must be derived from Warning, not %s"
        if isinstance(expected_warning, tuple):
            for exc in expected_warning:
                if not issubclass(exc, Warning):
                    raise TypeError(msg % type(exc))
            expected_warning_tup = expected_warning
        elif isinstance(expected_warning, type) and issubclass(
            expected_warning, Warning
        ):
            expected_warning_tup = (expected_warning,)
        else:
>           raise TypeError(msg % type(expected_warning))
E           TypeError: exceptions must be derived from Warning, not <class 'NoneType'>

/usr/lib/python3.11/site-packages/_pytest/recwarn.py:285: TypeError
```

The reason seems to be that `with pytest.warns(None):` is not a working method to check for that warnings are emitted with recent versions of pytest.

This fixes it for me.