### PR TITLE
Pin numpy version to 1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 torch
 torchvision
 Pillow>=9.0

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     long_description=long_description,
     license='Apache 2.0',
     install_requires=[
+        'numpy==1.26.4',
         'torch',
         'torchvision',
         'Pillow>=9.0',


### PR DESCRIPTION
**WHAT**
Pin numpy version to 1.26.4

**WHY**
`numpy 2.0.0` (latest as of now) seems to have issues with pytorch which leads to the exception-
`RuntimeError: Numpy is not available` whenever `torch.from_numpy` is called.

**HOW**
Pin numpy to the specified version in `setup.py`

**IMPLICATIONS**
The build fails on python<3.10. Several other packages, including numpy, scipy and matplotlib have dropped support for python<3.10. This PR is supported for python 3.10. In the next release, support for python 3.11 will also be added.