### PR TITLE
Re-generated .cpp handler for brute_force_cython_ext.cpp with cython==0.29.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install imagededup
 ```bash
 git clone https://github.com/idealo/imagededup.git
 cd imagededup
-pip install "cython>=0.29"
+pip install "cython>=0.29.34"
 python setup.py install
 ```  
 

--- a/imagededup/handlers/search/brute_force_cython_ext.cpp
+++ b/imagededup/handlers/search/brute_force_cython_ext.cpp
@@ -4,20 +4,7 @@
 {
     "distutils": {
         "depends": [
-            "imagededup/handlers/search/builtin/builtin.h"
-        ],
-        "extra_compile_args": [
-            "-O3",
-            "-march=native",
-            "-mtune=native",
-            "-stdlib=libc++"
-        ],
-        "extra_link_args": [
-            "-O3",
-            "-march=native",
-            "-mtune=native",
-            "-lc++",
-            "-nodefaultlibs"
+            "imagededup\\handlers\\search\\builtin\\builtin.h"
         ],
         "include_dirs": [
             "imagededup/handlers/search"
@@ -1004,7 +991,7 @@ static const char *__pyx_filename;
 
 
 static const char *__pyx_f[] = {
-  "imagededup/handlers/search/brute_force_cython_ext.pyx",
+  "imagededup\\handlers\\search\\brute_force_cython_ext.pyx",
   "stringsource",
 };
 
@@ -1324,7 +1311,7 @@ static const char __pyx_k_all_filenames[] = "all_filenames";
 static const char __pyx_k_query_hash_val[] = "query_hash_val";
 static const char __pyx_k_cline_in_traceback[] = "cline_in_traceback";
 static const char __pyx_k_brute_force_cython_ext[] = "brute_force_cython_ext";
-static const char __pyx_k_imagededup_handlers_search_brute[] = "imagededup/handlers/search/brute_force_cython_ext.pyx";
+static const char __pyx_k_imagededup_handlers_search_brute[] = "imagededup\\handlers\\search\\brute_force_cython_ext.pyx";
 static PyObject *__pyx_n_s_all_filenames;
 static PyObject *__pyx_n_s_all_hashes;
 static PyObject *__pyx_n_s_brute_force_cython_ext;

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ scikit-learn
 PyWavelets
 matplotlib
 # Development dependencies
-cython>=0.29
+cython>=0.29.34


### PR DESCRIPTION
To avoid the no member 'ob_digit' error as mentioned here: https://github.com/cython/cython/issues/5426, updated README and setup.py accordingly. This fixed the package not working with Python 3.12 (https://github.com/idealo/imagededup/issues/224)